### PR TITLE
refactor: migrate to Vulkan RAII

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .cache/
 build/
 shaders/*.spv
+.DS_Stores

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MyVulkanRenderer
 WIP
 
-# Credit
+## Credit
 - [Vulkan-Tutorial](https://github.com/KhronosGroup/Vulkan-Tutorial)
 - [littleVulkanEngine](https://github.com/blurrypiano/littleVulkanEngine)
 - [Vulkan Specification](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html)

--- a/src/core/pipeline.cpp
+++ b/src/core/pipeline.cpp
@@ -23,12 +23,12 @@ Pipeline::~Pipeline()
 {
 }
 
-void Pipeline::bind(VkCommandBuffer commandBuffer)
+void Pipeline::bind(const vk::raii::CommandBuffer &commandBuffer)
 {
-	vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, *graphicsPipeline);
+	commandBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, *graphicsPipeline);
 }
 
-PipelineConfigInfo Pipeline::defaultPipelineConfigInfo(uint32_t width, uint32_t height, vk::Format format)
+PipelineConfigInfo Pipeline::defaultPipelineConfigInfo(vk::Format format)
 {
 	PipelineConfigInfo configInfo{};
 

--- a/src/core/pipeline.cpp
+++ b/src/core/pipeline.cpp
@@ -51,7 +51,7 @@ PipelineConfigInfo Pipeline::defaultPipelineConfigInfo(vk::Format format)
 	    .rasterizerDiscardEnable = vk::False,
 	    .polygonMode             = vk::PolygonMode::eFill,
 	    .cullMode                = vk::CullModeFlagBits::eBack,
-	    .frontFace               = vk::FrontFace::eCounterClockwise,
+	    .frontFace               = vk::FrontFace::eClockwise,
 	    .depthBiasEnable         = vk::False,
 	    .depthBiasConstantFactor = 0.0f,        // optional
 	    .depthBiasClamp          = 0.0f,        // optional
@@ -102,11 +102,8 @@ PipelineConfigInfo Pipeline::defaultPipelineConfigInfo(vk::Format format)
 	    .pAttachments    = &configInfo.colorBlendAttachment,
 	    .blendConstants  = blendConstants,
 	};
-	// rendering
-	configInfo.rendering = {
-	    .colorAttachmentCount    = 1,
-	    .pColorAttachmentFormats = &format,
-	};
+	// rendering formats
+	configInfo.colorAttachmentFormats = {format};
 
 	// dynamicState
 	configInfo.dynamicStates = {
@@ -187,8 +184,8 @@ void Pipeline::createGraphicsPipeline(const std::string        &vertFilePath,
 	        .layout              = configInfo.pipelineLayout,
 	    },
 	    {
-	        .colorAttachmentCount    = configInfo.rendering.colorAttachmentCount,
-	        .pColorAttachmentFormats = configInfo.rendering.pColorAttachmentFormats,
+	        .colorAttachmentCount    = static_cast<uint32_t>(configInfo.colorAttachmentFormats.size()),
+	        .pColorAttachmentFormats = configInfo.colorAttachmentFormats.data(),
 	    }};
 
 	graphicsPipeline = vk::raii::Pipeline(device.device(), nullptr, pipelineInfoChain.get<vk::GraphicsPipelineCreateInfo>());

--- a/src/core/pipeline.cpp
+++ b/src/core/pipeline.cpp
@@ -21,9 +21,9 @@ Pipeline::Pipeline(VulkanDevice             &device,
 
 Pipeline::~Pipeline()
 {
-	vkDestroyShaderModule(device.device(), vertexShaderModule, nullptr);
-	vkDestroyShaderModule(device.device(), fragmentShaderModule, nullptr);
-	vkDestroyPipeline(device.device(), graphicsPipeline, nullptr);
+	vkDestroyShaderModule(*device.device(), vertexShaderModule, nullptr);
+	vkDestroyShaderModule(*device.device(), fragmentShaderModule, nullptr);
+	vkDestroyPipeline(*device.device(), graphicsPipeline, nullptr);
 }
 
 void Pipeline::bind(VkCommandBuffer commandBuffer)
@@ -189,7 +189,7 @@ void Pipeline::createGraphicsPipeline(const std::string        &vertFilePath,
 	pipelineInfo.basePipelineIndex  = -1;
 	pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
 
-	if (vkCreateGraphicsPipelines(device.device(), VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &graphicsPipeline) != VK_SUCCESS) {
+	if (vkCreateGraphicsPipelines(*device.device(), VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &graphicsPipeline) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create graphics pipeline");
 	}
 }
@@ -201,7 +201,7 @@ void Pipeline::createShaderModule(const std::vector<char> &code, VkShaderModule 
 	createInfo.codeSize = code.size();
 	createInfo.pCode    = reinterpret_cast<const uint32_t *>(code.data());
 
-	if (vkCreateShaderModule(device.device(), &createInfo, nullptr, shaderModule) != VK_SUCCESS) {
+	if (vkCreateShaderModule(*device.device(), &createInfo, nullptr, shaderModule) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create shader module");
 	}
 }

--- a/src/core/pipeline.cpp
+++ b/src/core/pipeline.cpp
@@ -21,8 +21,6 @@ Pipeline::Pipeline(VulkanDevice             &device,
 
 Pipeline::~Pipeline()
 {
-	vkDestroyShaderModule(*device.device(), vertexShaderModule, nullptr);
-	vkDestroyShaderModule(*device.device(), fragmentShaderModule, nullptr);
 	vkDestroyPipeline(*device.device(), graphicsPipeline, nullptr);
 }
 
@@ -127,31 +125,22 @@ void Pipeline::createGraphicsPipeline(const std::string        &vertFilePath,
                                       const std::string        &fragFilePath,
                                       const PipelineConfigInfo &configInfo)
 {
-	auto vertCode = readFile(vertFilePath);
-	auto fragCode = readFile(fragFilePath);
-
 	assert(configInfo.pipelineLayout != VK_NULL_HANDLE && "Cannot create pipeline with no layout provided");
 	assert(configInfo.renderPass != VK_NULL_HANDLE && "Cannot create pipeline with no render pass provided");
 
-	createShaderModule(vertCode, &vertexShaderModule);
-	createShaderModule(fragCode, &fragmentShaderModule);
+	vk::raii::ShaderModule vertexShaderModule   = createShaderModule(readFile(vertFilePath));
+	vk::raii::ShaderModule fragmentShaderModule = createShaderModule(readFile(fragFilePath));
 
-	VkPipelineShaderStageCreateInfo shaderStages[2];
-	shaderStages[0].sType               = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-	shaderStages[0].stage               = VK_SHADER_STAGE_VERTEX_BIT;
-	shaderStages[0].module              = vertexShaderModule;
-	shaderStages[0].pName               = "main";
-	shaderStages[0].flags               = 0;
-	shaderStages[0].pNext               = nullptr;
-	shaderStages[0].pSpecializationInfo = nullptr;
+	vk::PipelineShaderStageCreateInfo vertShaderStageInfo = {
+	    .stage  = vk::ShaderStageFlagBits::eVertex,
+	    .module = vertexShaderModule,
+	    .pName  = "main"};
+	vk::PipelineShaderStageCreateInfo fragShaderStageInfo = {
+	    .stage  = vk::ShaderStageFlagBits::eFragment,
+	    .module = fragmentShaderModule,
+	    .pName  = "main"};
 
-	shaderStages[1].sType               = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-	shaderStages[1].stage               = VK_SHADER_STAGE_FRAGMENT_BIT;
-	shaderStages[1].module              = fragmentShaderModule;
-	shaderStages[1].pName               = "main";
-	shaderStages[1].flags               = 0;
-	shaderStages[1].pNext               = nullptr;
-	shaderStages[1].pSpecializationInfo = nullptr;
+	vk::PipelineShaderStageCreateInfo shaderStages[] = {vertShaderStageInfo, fragShaderStageInfo};
 
 	auto                                 bindingDescriptions   = Model::Vertex::getBindingDescriptions();
 	auto                                 attributeDescriptions = Model::Vertex::getAttributeDescriptions();
@@ -172,7 +161,7 @@ void Pipeline::createGraphicsPipeline(const std::string        &vertFilePath,
 	VkGraphicsPipelineCreateInfo pipelineInfo{};
 	pipelineInfo.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
 	pipelineInfo.stageCount          = 2;
-	pipelineInfo.pStages             = shaderStages;
+	pipelineInfo.pStages             = *shaderStages;
 	pipelineInfo.pVertexInputState   = &vertexInputInfo;
 	pipelineInfo.pViewportState      = &viewportInfo;
 	pipelineInfo.pInputAssemblyState = &configInfo.inputAssemblyInfo;
@@ -194,16 +183,16 @@ void Pipeline::createGraphicsPipeline(const std::string        &vertFilePath,
 	}
 }
 
-void Pipeline::createShaderModule(const std::vector<char> &code, VkShaderModule *shaderModule)
+vk::raii::ShaderModule Pipeline::createShaderModule(const std::vector<char> &code)
 {
-	VkShaderModuleCreateInfo createInfo{};
-	createInfo.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-	createInfo.codeSize = code.size();
-	createInfo.pCode    = reinterpret_cast<const uint32_t *>(code.data());
+	vk::ShaderModuleCreateInfo createInfo = {
+	    .codeSize = code.size() * sizeof(char),
+	    .pCode    = reinterpret_cast<const uint32_t *>(code.data()),
+	};
 
-	if (vkCreateShaderModule(*device.device(), &createInfo, nullptr, shaderModule) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create shader module");
-	}
+	vk::raii::ShaderModule shaderModule(device.device(), createInfo);
+
+	return shaderModule;
 }
 
 }        // namespace mvr

--- a/src/core/pipeline.cpp
+++ b/src/core/pipeline.cpp
@@ -21,84 +21,101 @@ Pipeline::Pipeline(VulkanDevice             &device,
 
 Pipeline::~Pipeline()
 {
-	vkDestroyPipeline(*device.device(), graphicsPipeline, nullptr);
 }
 
 void Pipeline::bind(VkCommandBuffer commandBuffer)
 {
-	vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphicsPipeline);
+	vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, *graphicsPipeline);
 }
 
-PipelineConfigInfo Pipeline::defaultPipelineConfigInfo(uint32_t width, uint32_t height)
+PipelineConfigInfo Pipeline::defaultPipelineConfigInfo(uint32_t width, uint32_t height, vk::Format format)
 {
 	PipelineConfigInfo configInfo{};
 
+	// inputAssembly
+	configInfo.inputAssembly = {
+	    .topology               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+	    .primitiveRestartEnable = vk::False,
+	};
 	// viewport
-	configInfo.viewport.x        = 0.0f;
-	configInfo.viewport.y        = 0.0f;
-	configInfo.viewport.width    = static_cast<float>(width);
-	configInfo.viewport.height   = static_cast<float>(height);
-	configInfo.viewport.minDepth = 0.0f;
-	configInfo.viewport.maxDepth = 1.0f;
-	// scissor
-	configInfo.scissor.offset = {0, 0};
-	configInfo.scissor.extent = {width, height};
-	// inputAssemblyInfo
-	configInfo.inputAssemblyInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-	configInfo.inputAssemblyInfo.topology               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-	configInfo.inputAssemblyInfo.primitiveRestartEnable = VK_FALSE;
-	// rasterizationInfo
-	configInfo.rasterizationInfo.sType                   = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-	configInfo.rasterizationInfo.depthClampEnable        = VK_FALSE;
-	configInfo.rasterizationInfo.rasterizerDiscardEnable = VK_FALSE;
-	configInfo.rasterizationInfo.polygonMode             = VK_POLYGON_MODE_FILL;
-	configInfo.rasterizationInfo.lineWidth               = 1.0f;
-	configInfo.rasterizationInfo.cullMode                = VK_CULL_MODE_NONE;
-	configInfo.rasterizationInfo.frontFace               = VK_FRONT_FACE_CLOCKWISE;
-	configInfo.rasterizationInfo.depthBiasEnable         = VK_FALSE;
-	configInfo.rasterizationInfo.depthBiasConstantFactor = 0.0f;        // optional
-	configInfo.rasterizationInfo.depthBiasClamp          = 0.0f;        // optional
-	configInfo.rasterizationInfo.depthBiasSlopeFactor    = 0.0f;        // optional
-	// multisampleInfo
-	configInfo.multisampleInfo.sType                 = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-	configInfo.multisampleInfo.sampleShadingEnable   = VK_FALSE;
-	configInfo.multisampleInfo.rasterizationSamples  = VK_SAMPLE_COUNT_1_BIT;
-	configInfo.multisampleInfo.minSampleShading      = 1.0f;            // optional
-	configInfo.multisampleInfo.pSampleMask           = nullptr;         // optional
-	configInfo.multisampleInfo.alphaToCoverageEnable = VK_FALSE;        // optional
-	configInfo.multisampleInfo.alphaToOneEnable      = VK_FALSE;        // optional
-	// colorBlendAttachment
-	configInfo.colorBlendAttachment.colorWriteMask =
-	    VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-	    VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-	configInfo.colorBlendAttachment.blendEnable         = VK_FALSE;
-	configInfo.colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;         // optional
-	configInfo.colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ZERO;        // optional
-	configInfo.colorBlendAttachment.colorBlendOp        = VK_BLEND_OP_ADD;             // optional
-	configInfo.colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;         // optional
-	configInfo.colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;        // optional
-	configInfo.colorBlendAttachment.alphaBlendOp        = VK_BLEND_OP_ADD;             // optional
-	// colorBlendInfo
-	configInfo.colorBlendInfo.sType             = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-	configInfo.colorBlendInfo.logicOpEnable     = VK_FALSE;
-	configInfo.colorBlendInfo.logicOp           = VK_LOGIC_OP_COPY;        // optional
-	configInfo.colorBlendInfo.attachmentCount   = 1;
-	configInfo.colorBlendInfo.pAttachments      = &configInfo.colorBlendAttachment;
-	configInfo.colorBlendInfo.blendConstants[0] = 0.0f;        // optional
-	configInfo.colorBlendInfo.blendConstants[1] = 0.0f;        // optional
-	configInfo.colorBlendInfo.blendConstants[2] = 0.0f;        // optional
-	configInfo.colorBlendInfo.blendConstants[3] = 0.0f;        // optional
+	configInfo.viewport = vk::PipelineViewportStateCreateInfo{
+	    .viewportCount = 1,
+	    .pViewports    = nullptr,
+	    .scissorCount  = 1,
+	    .pScissors     = nullptr,
+	};
+	// rasterization
+	configInfo.rasterization = {
+	    .depthClampEnable        = vk::False,
+	    .rasterizerDiscardEnable = vk::False,
+	    .polygonMode             = vk::PolygonMode::eFill,
+	    .cullMode                = vk::CullModeFlagBits::eBack,
+	    .frontFace               = vk::FrontFace::eCounterClockwise,
+	    .depthBiasEnable         = vk::False,
+	    .depthBiasConstantFactor = 0.0f,        // optional
+	    .depthBiasClamp          = 0.0f,        // optional
+	    .depthBiasSlopeFactor    = 0.0f,        // optional
+	    .lineWidth               = 1.0f,
+	};
+	// multisample
+	configInfo.multisample = {
+	    .rasterizationSamples  = vk::SampleCountFlagBits::e1,
+	    .sampleShadingEnable   = vk::False,
+	    .minSampleShading      = 1.0f,             // optional
+	    .pSampleMask           = nullptr,          // optional
+	    .alphaToCoverageEnable = vk::False,        // optional
+	    .alphaToOneEnable      = vk::False,        // optional
+	};
 	// depthStencilInfo
-	configInfo.depthStencilInfo.sType                 = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-	configInfo.depthStencilInfo.depthTestEnable       = VK_TRUE;
-	configInfo.depthStencilInfo.depthWriteEnable      = VK_TRUE;
-	configInfo.depthStencilInfo.depthCompareOp        = VK_COMPARE_OP_LESS;
-	configInfo.depthStencilInfo.depthBoundsTestEnable = VK_FALSE;
-	configInfo.depthStencilInfo.minDepthBounds        = 0.0f;        // optional
-	configInfo.depthStencilInfo.maxDepthBounds        = 1.0f;        // optional
-	configInfo.depthStencilInfo.stencilTestEnable     = VK_FALSE;
-	configInfo.depthStencilInfo.front                 = {};        // optional
-	configInfo.depthStencilInfo.back                  = {};        // optional
+	configInfo.depthStencil = {
+	    .depthTestEnable       = vk::True,
+	    .depthWriteEnable      = vk::True,
+	    .depthCompareOp        = vk::CompareOp::eLess,
+	    .depthBoundsTestEnable = vk::False,
+	    .stencilTestEnable     = vk::False,
+	    .front                 = {},          // optional
+	    .back                  = {},          // optional
+	    .minDepthBounds        = 0.0f,        // optional
+	    .maxDepthBounds        = 1.0f,        // optional
+	};
+	// colorBlendAttachment
+	configInfo.colorBlendAttachment = {
+	    .blendEnable         = vk::False,
+	    .srcColorBlendFactor = vk::BlendFactor::eOne,         // optional
+	    .dstColorBlendFactor = vk::BlendFactor::eZero,        // optional
+	    .colorBlendOp        = vk::BlendOp::eAdd,             // optional
+	    .srcAlphaBlendFactor = vk::BlendFactor::eOne,         // optional
+	    .dstAlphaBlendFactor = vk::BlendFactor::eZero,        // optional
+	    .alphaBlendOp        = vk::BlendOp::eAdd,             // optional
+	    .colorWriteMask =
+	        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
+	        vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
+	};
+	// blendConstants
+	std::array blendConstants = {0.0f, 0.0f, 0.0f, 0.0f};
+	// colorBlend
+	configInfo.colorBlend = {
+	    .logicOpEnable   = vk::False,
+	    .logicOp         = vk::LogicOp::eCopy,
+	    .attachmentCount = 1,
+	    .pAttachments    = &configInfo.colorBlendAttachment,
+	    .blendConstants  = blendConstants,
+	};
+	// rendering
+	configInfo.rendering = {
+	    .colorAttachmentCount    = 1,
+	    .pColorAttachmentFormats = &format,
+	};
+
+	// dynamicState
+	configInfo.dynamicStates = {
+	    vk::DynamicState::eViewport,
+	    vk::DynamicState::eScissor,
+	};
+	configInfo.dynamicStateInfo = {
+	    .dynamicStateCount = static_cast<uint32_t>(configInfo.dynamicStates.size()),
+	    .pDynamicStates    = configInfo.dynamicStates.data(),
+	};
 
 	return configInfo;
 }
@@ -126,61 +143,54 @@ void Pipeline::createGraphicsPipeline(const std::string        &vertFilePath,
                                       const PipelineConfigInfo &configInfo)
 {
 	assert(configInfo.pipelineLayout != VK_NULL_HANDLE && "Cannot create pipeline with no layout provided");
-	assert(configInfo.renderPass != VK_NULL_HANDLE && "Cannot create pipeline with no render pass provided");
 
+	// create shader modules and shader stages
 	vk::raii::ShaderModule vertexShaderModule   = createShaderModule(readFile(vertFilePath));
 	vk::raii::ShaderModule fragmentShaderModule = createShaderModule(readFile(fragFilePath));
 
 	vk::PipelineShaderStageCreateInfo vertShaderStageInfo = {
 	    .stage  = vk::ShaderStageFlagBits::eVertex,
 	    .module = vertexShaderModule,
-	    .pName  = "main"};
+	    .pName  = "main",
+	};
 	vk::PipelineShaderStageCreateInfo fragShaderStageInfo = {
 	    .stage  = vk::ShaderStageFlagBits::eFragment,
 	    .module = fragmentShaderModule,
-	    .pName  = "main"};
+	    .pName  = "main",
+	};
 
 	vk::PipelineShaderStageCreateInfo shaderStages[] = {vertShaderStageInfo, fragShaderStageInfo};
 
-	auto                                 bindingDescriptions   = Model::Vertex::getBindingDescriptions();
-	auto                                 attributeDescriptions = Model::Vertex::getAttributeDescriptions();
-	VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
-	vertexInputInfo.sType                           = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-	vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(attributeDescriptions.size());
-	vertexInputInfo.vertexBindingDescriptionCount   = static_cast<uint32_t>(bindingDescriptions.size());
-	vertexInputInfo.pVertexAttributeDescriptions    = attributeDescriptions.data();
-	vertexInputInfo.pVertexBindingDescriptions      = bindingDescriptions.data();
+	// create vertex input state
+	auto                                   bindingDescriptions   = Model::Vertex::getBindingDescriptions();
+	auto                                   attributeDescriptions = Model::Vertex::getAttributeDescriptions();
+	vk::PipelineVertexInputStateCreateInfo vertexInput           = {
+	              .vertexBindingDescriptionCount   = static_cast<uint32_t>(bindingDescriptions.size()),
+	              .pVertexBindingDescriptions      = bindingDescriptions.data(),
+	              .vertexAttributeDescriptionCount = static_cast<uint32_t>(attributeDescriptions.size()),
+	              .pVertexAttributeDescriptions    = attributeDescriptions.data(),
+    };
 
-	VkPipelineViewportStateCreateInfo viewportInfo{};
-	viewportInfo.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-	viewportInfo.viewportCount = 1;
-	viewportInfo.pViewports    = &configInfo.viewport;
-	viewportInfo.scissorCount  = 1;
-	viewportInfo.pScissors     = &configInfo.scissor;
+	vk::StructureChain<vk::GraphicsPipelineCreateInfo, vk::PipelineRenderingCreateInfo> pipelineInfoChain = {
+	    {
+	        .stageCount          = 2,
+	        .pStages             = shaderStages,
+	        .pVertexInputState   = &vertexInput,
+	        .pInputAssemblyState = &configInfo.inputAssembly,
+	        .pViewportState      = &configInfo.viewport,
+	        .pRasterizationState = &configInfo.rasterization,
+	        .pMultisampleState   = &configInfo.multisample,
+	        .pDepthStencilState  = &configInfo.depthStencil,
+	        .pColorBlendState    = &configInfo.colorBlend,
+	        .pDynamicState       = &configInfo.dynamicStateInfo,
+	        .layout              = configInfo.pipelineLayout,
+	    },
+	    {
+	        .colorAttachmentCount    = configInfo.rendering.colorAttachmentCount,
+	        .pColorAttachmentFormats = configInfo.rendering.pColorAttachmentFormats,
+	    }};
 
-	VkGraphicsPipelineCreateInfo pipelineInfo{};
-	pipelineInfo.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-	pipelineInfo.stageCount          = 2;
-	pipelineInfo.pStages             = *shaderStages;
-	pipelineInfo.pVertexInputState   = &vertexInputInfo;
-	pipelineInfo.pViewportState      = &viewportInfo;
-	pipelineInfo.pInputAssemblyState = &configInfo.inputAssemblyInfo;
-	pipelineInfo.pRasterizationState = &configInfo.rasterizationInfo;
-	pipelineInfo.pMultisampleState   = &configInfo.multisampleInfo;
-	pipelineInfo.pColorBlendState    = &configInfo.colorBlendInfo;
-	pipelineInfo.pDepthStencilState  = &configInfo.depthStencilInfo;
-	pipelineInfo.pDynamicState       = nullptr;
-
-	pipelineInfo.layout     = configInfo.pipelineLayout;
-	pipelineInfo.renderPass = configInfo.renderPass;
-	pipelineInfo.subpass    = configInfo.subpass;
-
-	pipelineInfo.basePipelineIndex  = -1;
-	pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
-
-	if (vkCreateGraphicsPipelines(*device.device(), VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &graphicsPipeline) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create graphics pipeline");
-	}
+	graphicsPipeline = vk::raii::Pipeline(device.device(), nullptr, pipelineInfoChain.get<vk::GraphicsPipelineCreateInfo>());
 }
 
 vk::raii::ShaderModule Pipeline::createShaderModule(const std::vector<char> &code)

--- a/src/core/pipeline.cpp
+++ b/src/core/pipeline.cpp
@@ -34,11 +34,12 @@ PipelineConfigInfo Pipeline::defaultPipelineConfigInfo(uint32_t width, uint32_t 
 
 	// inputAssembly
 	configInfo.inputAssembly = {
-	    .topology               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+	    .topology               = vk::PrimitiveTopology::eTriangleList,
 	    .primitiveRestartEnable = vk::False,
 	};
 	// viewport
 	configInfo.viewport = vk::PipelineViewportStateCreateInfo{
+	    // TODO: abbreviate this struct declaration
 	    .viewportCount = 1,
 	    .pViewports    = nullptr,
 	    .scissorCount  = 1,

--- a/src/core/pipeline.h
+++ b/src/core/pipeline.h
@@ -37,8 +37,8 @@ class Pipeline
 	Pipeline(const Pipeline &)            = delete;
 	Pipeline &operator=(const Pipeline &) = delete;
 
-	void                      bind(VkCommandBuffer commandBuffer);
-	static PipelineConfigInfo defaultPipelineConfigInfo(uint32_t width, uint32_t height, vk::Format format);
+	void                      bind(const vk::raii::CommandBuffer &commandBuffer);
+	static PipelineConfigInfo defaultPipelineConfigInfo(vk::Format format);
 
   private:
 	static std::vector<char> readFile(const std::string &filePath);

--- a/src/core/pipeline.h
+++ b/src/core/pipeline.h
@@ -17,7 +17,7 @@ struct PipelineConfigInfo {
 	vk::PipelineDepthStencilStateCreateInfo  depthStencil;
 	vk::PipelineColorBlendAttachmentState    colorBlendAttachment;
 	vk::PipelineColorBlendStateCreateInfo    colorBlend;
-	vk::PipelineRenderingCreateInfo          rendering;
+	std::vector<vk::Format>                  colorAttachmentFormats;
 
 	vk::PipelineLayout pipelineLayout;
 

--- a/src/core/pipeline.h
+++ b/src/core/pipeline.h
@@ -10,17 +10,19 @@ namespace mvr
 {
 
 struct PipelineConfigInfo {
-	VkViewport                             viewport;
-	VkRect2D                               scissor;
-	VkPipelineInputAssemblyStateCreateInfo inputAssemblyInfo;
-	VkPipelineRasterizationStateCreateInfo rasterizationInfo;
-	VkPipelineMultisampleStateCreateInfo   multisampleInfo;
-	VkPipelineColorBlendAttachmentState    colorBlendAttachment;
-	VkPipelineColorBlendStateCreateInfo    colorBlendInfo;
-	VkPipelineDepthStencilStateCreateInfo  depthStencilInfo;
-	VkPipelineLayout                       pipelineLayout = VK_NULL_HANDLE;
-	VkRenderPass                           renderPass     = VK_NULL_HANDLE;
-	uint32_t                               subpass        = 0;
+	vk::PipelineInputAssemblyStateCreateInfo inputAssembly;
+	vk::PipelineViewportStateCreateInfo      viewport;
+	vk::PipelineRasterizationStateCreateInfo rasterization;
+	vk::PipelineMultisampleStateCreateInfo   multisample;
+	vk::PipelineDepthStencilStateCreateInfo  depthStencil;
+	vk::PipelineColorBlendAttachmentState    colorBlendAttachment;
+	vk::PipelineColorBlendStateCreateInfo    colorBlend;
+	vk::PipelineRenderingCreateInfo          rendering;
+
+	vk::PipelineLayout pipelineLayout;
+
+	std::vector<vk::DynamicState>      dynamicStates;
+	vk::PipelineDynamicStateCreateInfo dynamicStateInfo;
 };
 
 class Pipeline
@@ -36,7 +38,7 @@ class Pipeline
 	Pipeline &operator=(const Pipeline &) = delete;
 
 	void                      bind(VkCommandBuffer commandBuffer);
-	static PipelineConfigInfo defaultPipelineConfigInfo(uint32_t width, uint32_t height);
+	static PipelineConfigInfo defaultPipelineConfigInfo(uint32_t width, uint32_t height, vk::Format format);
 
   private:
 	static std::vector<char> readFile(const std::string &filePath);
@@ -45,8 +47,8 @@ class Pipeline
 	                                                const std::string        &fragFilePath,
 	                                                const PipelineConfigInfo &configInfo);
 
-	VulkanDevice &device;
-	VkPipeline    graphicsPipeline;
+	VulkanDevice      &device;
+	vk::raii::Pipeline graphicsPipeline = nullptr;
 };
 
 }        // namespace mvr

--- a/src/core/pipeline.h
+++ b/src/core/pipeline.h
@@ -40,15 +40,13 @@ class Pipeline
 
   private:
 	static std::vector<char> readFile(const std::string &filePath);
+	vk::raii::ShaderModule   createShaderModule(const std::vector<char> &code);
 	void                     createGraphicsPipeline(const std::string        &vertFilePath,
 	                                                const std::string        &fragFilePath,
 	                                                const PipelineConfigInfo &configInfo);
-	void                     createShaderModule(const std::vector<char> &code, VkShaderModule *shaderModule);
 
-	VulkanDevice  &device;
-	VkPipeline     graphicsPipeline;
-	VkShaderModule vertexShaderModule;
-	VkShaderModule fragmentShaderModule;
+	VulkanDevice &device;
+	VkPipeline    graphicsPipeline;
 };
 
 }        // namespace mvr

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -1,8 +1,10 @@
 #include "swap_chain.h"
+#include "vulkan/vulkan.hpp"
 
 // std
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -27,11 +29,6 @@ SwapChain::SwapChain(VulkanDevice &device, VkExtent2D windowExtent) : device{dev
 
 SwapChain::~SwapChain()
 {
-	for (auto imageView : swapChainImageViews) {
-		vkDestroyImageView(*device.device(), imageView, nullptr);
-	}
-	swapChainImageViews.clear();
-
 	for (int i = 0; i < depthImages.size(); i++) {
 		vkDestroyImageView(*device.device(), depthImageViews[i], nullptr);
 		vkDestroyImage(*device.device(), depthImages[i], nullptr);
@@ -171,23 +168,16 @@ void SwapChain::createSwapChain()
 
 void SwapChain::createImageViews()
 {
-	swapChainImageViews.resize(swapChainImages.size());
-	for (size_t i = 0; i < swapChainImages.size(); i++) {
-		VkImageViewCreateInfo viewInfo{};
-		viewInfo.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-		viewInfo.image                           = swapChainImages[i];
-		viewInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-		viewInfo.format                          = static_cast<VkFormat>(swapChainSurfaceFormat.format);
-		viewInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
-		viewInfo.subresourceRange.baseMipLevel   = 0;
-		viewInfo.subresourceRange.levelCount     = 1;
-		viewInfo.subresourceRange.baseArrayLayer = 0;
-		viewInfo.subresourceRange.layerCount     = 1;
+	assert(swapChainImageViews.empty());
 
-		if (vkCreateImageView(*device.device(), &viewInfo, nullptr, &swapChainImageViews[i]) !=
-		    VK_SUCCESS) {
-			throw std::runtime_error("failed to create texture image view!");
-		}
+	vk::ImageViewCreateInfo imageviewCreateInfo = {
+	    .viewType         = vk::ImageViewType::e2D,
+	    .format           = swapChainSurfaceFormat.format,
+	    .subresourceRange = {vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1}};
+
+	for (auto &image : swapChainImages) {
+		imageviewCreateInfo.image = image;
+		swapChainImageViews.emplace_back(device.device(), imageviewCreateInfo);
 	}
 }
 
@@ -306,7 +296,7 @@ void SwapChain::createFramebuffers()
 {
 	swapChainFramebuffers.resize(imageCount());
 	for (size_t i = 0; i < imageCount(); i++) {
-		std::array<VkImageView, 2> attachments = {swapChainImageViews[i], depthImageViews[i]};
+		std::array<VkImageView, 2> attachments = {*swapChainImageViews[i], depthImageViews[i]};
 
 		VkExtent2D              swapChainExtent = getSwapChainExtent();
 		VkFramebufferCreateInfo framebufferInfo = {};

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -270,7 +270,7 @@ void SwapChain::createDepthResources()
 
 		device.createImageWithInfo(
 		    imageInfo,
-		    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+		    vk::MemoryPropertyFlagBits::eDeviceLocal,
 		    depthImages[i],
 		    depthImageMemorys[i]);
 

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <limits>
 #include <stdexcept>
+#include <vulkan/vulkan_core.h>
 
 namespace mvr
 {
@@ -198,7 +199,7 @@ void SwapChain::createRenderPass()
 	depthAttachmentRef.layout     = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
 	VkAttachmentDescription colorAttachment = {};
-	colorAttachment.format                  = getSwapChainSurfaceFormat();
+	colorAttachment.format                  = static_cast<VkFormat>(getSwapChainSurfaceFormat());
 	colorAttachment.samples                 = VK_SAMPLE_COUNT_1_BIT;
 	colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_CLEAR;
 	colorAttachment.storeOp                 = VK_ATTACHMENT_STORE_OP_STORE;

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -1,5 +1,4 @@
 #include "swap_chain.h"
-#include "vulkan/vulkan.hpp"
 
 // std
 #include <algorithm>
@@ -11,7 +10,6 @@
 #include <iostream>
 #include <limits>
 #include <stdexcept>
-#include <vulkan/vulkan_core.h>
 
 namespace mvr
 {

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -379,7 +379,7 @@ VkSurfaceFormatKHR SwapChain::chooseSwapSurfaceFormat(
     const std::vector<VkSurfaceFormatKHR> &availableFormats)
 {
 	for (const auto &availableFormat : availableFormats) {
-		if (availableFormat.format == VK_FORMAT_B8G8R8A8_UNORM &&
+		if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB &&
 		    availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
 			return availableFormat;
 		}

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -2,12 +2,10 @@
 
 // std
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
 #include <limits>
 #include <stdexcept>
 
@@ -20,9 +18,7 @@ SwapChain::SwapChain(VulkanDevice &device, VkExtent2D windowExtent) : device{dev
 {
 	createSwapChain();
 	createImageViews();
-	createRenderPass();
 	createDepthResources();
-	createFramebuffers();
 	createSyncObjects();
 }
 
@@ -33,91 +29,47 @@ SwapChain::~SwapChain()
 		vkDestroyImage(*device.device(), depthImages[i], nullptr);
 		vkFreeMemory(*device.device(), depthImageMemorys[i], nullptr);
 	}
-
-	for (auto framebuffer : swapChainFramebuffers) {
-		vkDestroyFramebuffer(*device.device(), framebuffer, nullptr);
-	}
-
-	vkDestroyRenderPass(*device.device(), renderPass, nullptr);
-
-	// cleanup synchronization objects
-	for (size_t i = 0; i < renderFinishedSemaphores.size(); i++) {
-		vkDestroySemaphore(*device.device(), renderFinishedSemaphores[i], nullptr);
-	}
-	for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-		vkDestroySemaphore(*device.device(), imageAvailableSemaphores[i], nullptr);
-		vkDestroyFence(*device.device(), inFlightFences[i], nullptr);
-	}
 }
 
 // Public Methods
 
-VkResult SwapChain::acquireNextImage(uint32_t *imageIndex)
+std::pair<vk::Result, uint32_t> SwapChain::acquireNextImage(uint32_t frameIndex)
 {
-	vkWaitForFences(
-	    *device.device(),
-	    1,
-	    &inFlightFences[currentFrame],
-	    VK_TRUE,
-	    std::numeric_limits<uint64_t>::max());
+	auto fenceResult = device.device().waitForFences(*inFlightFences[frameIndex], vk::True, UINT64_MAX);
+	if (fenceResult != vk::Result::eSuccess) {
+		throw std::runtime_error("failed to wait for fence!");
+	}
+	device.device().resetFences(*inFlightFences[frameIndex]);
 
-	VkResult result = vkAcquireNextImageKHR(
-	    *device.device(),
-	    *swapChain,
-	    std::numeric_limits<uint64_t>::max(),
-	    imageAvailableSemaphores[currentFrame],        // must be a not signaled semaphore
-	    VK_NULL_HANDLE,
-	    imageIndex);
+	auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *imageAvailableSemaphores[frameIndex], nullptr);
 
-	return result;
+	return {result, imageIndex};
 }
 
-VkResult SwapChain::submitCommandBuffers(const VkCommandBuffer *buffers, uint32_t *imageIndex)
+vk::Result SwapChain::submitCommandBuffers(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex, uint32_t frameIndex)
 {
-	if (imagesInFlight[*imageIndex] != VK_NULL_HANDLE) {
-		vkWaitForFences(*device.device(), 1, &imagesInFlight[*imageIndex], VK_TRUE, UINT64_MAX);
-	}
-	imagesInFlight[*imageIndex] = inFlightFences[currentFrame];
+	vk::PipelineStageFlags waitDestinationStageMask(vk::PipelineStageFlagBits::eColorAttachmentOutput);
+	const vk::SubmitInfo   submitInfo{
+	    .waitSemaphoreCount   = 1,
+	    .pWaitSemaphores      = &*imageAvailableSemaphores[frameIndex],
+	    .pWaitDstStageMask    = &waitDestinationStageMask,
+	    .commandBufferCount   = 1,
+	    .pCommandBuffers      = &*commandBuffer,
+	    .signalSemaphoreCount = 1,
+	    .pSignalSemaphores    = &*renderFinishedSemaphores[imageIndex]
+	};
 
-	VkSubmitInfo submitInfo = {};
-	submitInfo.sType        = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+	device.graphicsQueue().submit(submitInfo, *inFlightFences[frameIndex]);
 
-	VkSemaphore          waitSemaphores[] = {imageAvailableSemaphores[currentFrame]};
-	VkPipelineStageFlags waitStages[]     = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};
-	submitInfo.waitSemaphoreCount         = 1;
-	submitInfo.pWaitSemaphores            = waitSemaphores;
-	submitInfo.pWaitDstStageMask          = waitStages;
+	const vk::PresentInfoKHR presentInfoKHR{
+	    .waitSemaphoreCount = 1,
+	    .pWaitSemaphores    = &*renderFinishedSemaphores[imageIndex],
+	    .swapchainCount     = 1,
+	    .pSwapchains        = &*swapChain,
+	    .pImageIndices      = &imageIndex
+	};
 
-	submitInfo.commandBufferCount = 1;
-	submitInfo.pCommandBuffers    = buffers;
-
-	VkSemaphore signalSemaphores[]  = {renderFinishedSemaphores[*imageIndex]};
-	submitInfo.signalSemaphoreCount = 1;
-	submitInfo.pSignalSemaphores    = signalSemaphores;
-
-	vkResetFences(*device.device(), 1, &inFlightFences[currentFrame]);
-	if (vkQueueSubmit(device.graphicsQueue(), 1, &submitInfo, inFlightFences[currentFrame]) !=
-	    VK_SUCCESS) {
-		throw std::runtime_error("failed to submit draw command buffer!");
-	}
-
-	VkPresentInfoKHR presentInfo = {};
-	presentInfo.sType            = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-
-	presentInfo.waitSemaphoreCount = 1;
-	presentInfo.pWaitSemaphores    = signalSemaphores;
-
-	VkSwapchainKHR swapChains[] = {*swapChain};
-	presentInfo.swapchainCount  = 1;
-	presentInfo.pSwapchains     = swapChains;
-
-	presentInfo.pImageIndices = imageIndex;
-
-	auto result = vkQueuePresentKHR(device.presentQueue(), &presentInfo);
-
-	currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
-
-	return result;
+	return device.presentQueue().presentKHR(presentInfoKHR);
 }
 
 VkFormat SwapChain::findDepthFormat()
@@ -180,68 +132,6 @@ void SwapChain::createImageViews()
 	}
 }
 
-void SwapChain::createRenderPass()
-{
-	VkAttachmentDescription depthAttachment{};
-	depthAttachment.format         = findDepthFormat();
-	depthAttachment.samples        = VK_SAMPLE_COUNT_1_BIT;
-	depthAttachment.loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	depthAttachment.storeOp        = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	depthAttachment.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	depthAttachment.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
-	depthAttachment.finalLayout    = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-	VkAttachmentReference depthAttachmentRef{};
-	depthAttachmentRef.attachment = 1;
-	depthAttachmentRef.layout     = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-	VkAttachmentDescription colorAttachment = {};
-	colorAttachment.format                  = static_cast<VkFormat>(getSwapChainSurfaceFormat());
-	colorAttachment.samples                 = VK_SAMPLE_COUNT_1_BIT;
-	colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	colorAttachment.storeOp                 = VK_ATTACHMENT_STORE_OP_STORE;
-	colorAttachment.stencilStoreOp          = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	colorAttachment.stencilLoadOp           = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	colorAttachment.initialLayout           = VK_IMAGE_LAYOUT_UNDEFINED;
-	colorAttachment.finalLayout             = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-
-	VkAttachmentReference colorAttachmentRef = {};
-	colorAttachmentRef.attachment            = 0;
-	colorAttachmentRef.layout                = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-	VkSubpassDescription subpass    = {};
-	subpass.pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS;
-	subpass.colorAttachmentCount    = 1;
-	subpass.pColorAttachments       = &colorAttachmentRef;
-	subpass.pDepthStencilAttachment = &depthAttachmentRef;
-
-	VkSubpassDependency dependency = {};
-	dependency.srcSubpass          = VK_SUBPASS_EXTERNAL;
-	dependency.srcAccessMask       = 0;
-	dependency.srcStageMask =
-	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-	dependency.dstSubpass = 0;
-	dependency.dstStageMask =
-	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-	dependency.dstAccessMask =
-	    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-
-	std::array<VkAttachmentDescription, 2> attachments    = {colorAttachment, depthAttachment};
-	VkRenderPassCreateInfo                 renderPassInfo = {};
-	renderPassInfo.sType                                  = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-	renderPassInfo.attachmentCount                        = static_cast<uint32_t>(attachments.size());
-	renderPassInfo.pAttachments                           = attachments.data();
-	renderPassInfo.subpassCount                           = 1;
-	renderPassInfo.pSubpasses                             = &subpass;
-	renderPassInfo.dependencyCount                        = 1;
-	renderPassInfo.pDependencies                          = &dependency;
-
-	if (vkCreateRenderPass(*device.device(), &renderPassInfo, nullptr, &renderPass) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create render pass!");
-	}
-}
-
 void SwapChain::createDepthResources()
 {
 	VkFormat   depthFormat     = findDepthFormat();
@@ -291,59 +181,17 @@ void SwapChain::createDepthResources()
 	}
 }
 
-void SwapChain::createFramebuffers()
-{
-	swapChainFramebuffers.resize(imageCount());
-	for (size_t i = 0; i < imageCount(); i++) {
-		std::array<VkImageView, 2> attachments = {*swapChainImageViews[i], depthImageViews[i]};
-
-		VkExtent2D              swapChainExtent = getSwapChainExtent();
-		VkFramebufferCreateInfo framebufferInfo = {};
-		framebufferInfo.sType                   = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		framebufferInfo.renderPass              = renderPass;
-		framebufferInfo.attachmentCount         = static_cast<uint32_t>(attachments.size());
-		framebufferInfo.pAttachments            = attachments.data();
-		framebufferInfo.width                   = swapChainExtent.width;
-		framebufferInfo.height                  = swapChainExtent.height;
-		framebufferInfo.layers                  = 1;
-
-		if (vkCreateFramebuffer(
-		        *device.device(),
-		        &framebufferInfo,
-		        nullptr,
-		        &swapChainFramebuffers[i]) != VK_SUCCESS) {
-			throw std::runtime_error("failed to create framebuffer!");
-		}
-	}
-}
-
 void SwapChain::createSyncObjects()
 {
-	imageAvailableSemaphores.resize(MAX_FRAMES_IN_FLIGHT);
-	renderFinishedSemaphores.resize(imageCount());
-	inFlightFences.resize(MAX_FRAMES_IN_FLIGHT);
-	imagesInFlight.resize(imageCount(), VK_NULL_HANDLE);
+	assert(renderFinishedSemaphores.empty() && imageAvailableSemaphores.empty() && inFlightFences.empty());
 
-	VkSemaphoreCreateInfo semaphoreInfo = {};
-	semaphoreInfo.sType                 = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-
-	VkFenceCreateInfo fenceInfo = {};
-	fenceInfo.sType             = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-	fenceInfo.flags             = VK_FENCE_CREATE_SIGNALED_BIT;
-
-	for (size_t i = 0; i < imageCount(); i++) {
-		if (vkCreateSemaphore(*device.device(), &semaphoreInfo, nullptr, &renderFinishedSemaphores[i]) !=
-		    VK_SUCCESS) {
-			throw std::runtime_error("failed to create synchronization objects for a frame!");
-		}
+	for (size_t i = 0; i < swapChainImages.size(); i++) {
+		renderFinishedSemaphores.emplace_back(device.device(), vk::SemaphoreCreateInfo{});
 	}
 
 	for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-		if (vkCreateSemaphore(*device.device(), &semaphoreInfo, nullptr, &imageAvailableSemaphores[i]) !=
-		        VK_SUCCESS ||
-		    vkCreateFence(*device.device(), &fenceInfo, nullptr, &inFlightFences[i]) != VK_SUCCESS) {
-			throw std::runtime_error("failed to create synchronization objects for a frame!");
-		}
+		imageAvailableSemaphores.emplace_back(device.device(), vk::SemaphoreCreateInfo{});
+		inFlightFences.emplace_back(device.device(), vk::FenceCreateInfo{.flags = vk::FenceCreateFlagBits::eSignaled});
 	}
 }
 

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -1,7 +1,10 @@
 #include "swap_chain.h"
+#include "vulkan/vulkan.hpp"
 
 // std
+#include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -11,7 +14,7 @@
 namespace mvr
 {
 
-SwapChain::SwapChain(VulkanDevice &deviceRef, VkExtent2D windowExtent) : device{deviceRef}, windowExtent{windowExtent}
+SwapChain::SwapChain(VulkanDevice &device, VkExtent2D windowExtent) : device{device}, windowExtent{windowExtent}
 {
 	createSwapChain();
 	createImageViews();
@@ -24,49 +27,44 @@ SwapChain::SwapChain(VulkanDevice &deviceRef, VkExtent2D windowExtent) : device{
 SwapChain::~SwapChain()
 {
 	for (auto imageView : swapChainImageViews) {
-		vkDestroyImageView(device.device(), imageView, nullptr);
+		vkDestroyImageView(*device.device(), imageView, nullptr);
 	}
 	swapChainImageViews.clear();
 
-	if (swapChain != nullptr) {
-		vkDestroySwapchainKHR(device.device(), swapChain, nullptr);
-		swapChain = nullptr;
-	}
-
 	for (int i = 0; i < depthImages.size(); i++) {
-		vkDestroyImageView(device.device(), depthImageViews[i], nullptr);
-		vkDestroyImage(device.device(), depthImages[i], nullptr);
-		vkFreeMemory(device.device(), depthImageMemorys[i], nullptr);
+		vkDestroyImageView(*device.device(), depthImageViews[i], nullptr);
+		vkDestroyImage(*device.device(), depthImages[i], nullptr);
+		vkFreeMemory(*device.device(), depthImageMemorys[i], nullptr);
 	}
 
 	for (auto framebuffer : swapChainFramebuffers) {
-		vkDestroyFramebuffer(device.device(), framebuffer, nullptr);
+		vkDestroyFramebuffer(*device.device(), framebuffer, nullptr);
 	}
 
-	vkDestroyRenderPass(device.device(), renderPass, nullptr);
+	vkDestroyRenderPass(*device.device(), renderPass, nullptr);
 
 	// cleanup synchronization objects
 	for (size_t i = 0; i < renderFinishedSemaphores.size(); i++) {
-		vkDestroySemaphore(device.device(), renderFinishedSemaphores[i], nullptr);
+		vkDestroySemaphore(*device.device(), renderFinishedSemaphores[i], nullptr);
 	}
 	for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-		vkDestroySemaphore(device.device(), imageAvailableSemaphores[i], nullptr);
-		vkDestroyFence(device.device(), inFlightFences[i], nullptr);
+		vkDestroySemaphore(*device.device(), imageAvailableSemaphores[i], nullptr);
+		vkDestroyFence(*device.device(), inFlightFences[i], nullptr);
 	}
 }
 
 VkResult SwapChain::acquireNextImage(uint32_t *imageIndex)
 {
 	vkWaitForFences(
-	    device.device(),
+	    *device.device(),
 	    1,
 	    &inFlightFences[currentFrame],
 	    VK_TRUE,
 	    std::numeric_limits<uint64_t>::max());
 
 	VkResult result = vkAcquireNextImageKHR(
-	    device.device(),
-	    swapChain,
+	    *device.device(),
+	    *swapChain,
 	    std::numeric_limits<uint64_t>::max(),
 	    imageAvailableSemaphores[currentFrame],        // must be a not signaled semaphore
 	    VK_NULL_HANDLE,
@@ -79,7 +77,7 @@ VkResult SwapChain::submitCommandBuffers(
     const VkCommandBuffer *buffers, uint32_t *imageIndex)
 {
 	if (imagesInFlight[*imageIndex] != VK_NULL_HANDLE) {
-		vkWaitForFences(device.device(), 1, &imagesInFlight[*imageIndex], VK_TRUE, UINT64_MAX);
+		vkWaitForFences(*device.device(), 1, &imagesInFlight[*imageIndex], VK_TRUE, UINT64_MAX);
 	}
 	imagesInFlight[*imageIndex] = inFlightFences[currentFrame];
 
@@ -99,7 +97,7 @@ VkResult SwapChain::submitCommandBuffers(
 	submitInfo.signalSemaphoreCount = 1;
 	submitInfo.pSignalSemaphores    = signalSemaphores;
 
-	vkResetFences(device.device(), 1, &inFlightFences[currentFrame]);
+	vkResetFences(*device.device(), 1, &inFlightFences[currentFrame]);
 	if (vkQueueSubmit(device.graphicsQueue(), 1, &submitInfo, inFlightFences[currentFrame]) !=
 	    VK_SUCCESS) {
 		throw std::runtime_error("failed to submit draw command buffer!");
@@ -111,7 +109,7 @@ VkResult SwapChain::submitCommandBuffers(
 	presentInfo.waitSemaphoreCount = 1;
 	presentInfo.pWaitSemaphores    = signalSemaphores;
 
-	VkSwapchainKHR swapChains[] = {swapChain};
+	VkSwapchainKHR swapChains[] = {*swapChain};
 	presentInfo.swapchainCount  = 1;
 	presentInfo.pSwapchains     = swapChains;
 
@@ -128,62 +126,40 @@ void SwapChain::createSwapChain()
 {
 	SwapChainSupportDetails swapChainSupport = device.getSwapChainSupport();
 
-	VkSurfaceFormatKHR surfaceFormat = chooseSwapSurfaceFormat(swapChainSupport.formats);
-	VkPresentModeKHR   presentMode   = chooseSwapPresentMode(swapChainSupport.presentModes);
-	VkExtent2D         extent        = chooseSwapExtent(swapChainSupport.capabilities);
+	swapChainSurfaceFormat         = chooseSwapSurfaceFormat(swapChainSupport.formats);
+	vk::PresentModeKHR presentMode = chooseSwapPresentMode(swapChainSupport.presentModes);
+	swapChainExtent                = chooseSwapExtent(swapChainSupport.capabilities);
+	uint32_t imageCount            = chooseSwapMinImageCount(swapChainSupport.capabilities);
 
-	uint32_t imageCount = swapChainSupport.capabilities.minImageCount + 1;
-	if (swapChainSupport.capabilities.maxImageCount > 0 &&
-	    imageCount > swapChainSupport.capabilities.maxImageCount) {
-		imageCount = swapChainSupport.capabilities.maxImageCount;
-	}
-
-	VkSwapchainCreateInfoKHR createInfo = {};
-	createInfo.sType                    = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-	createInfo.surface                  = device.surface();
-
-	createInfo.minImageCount    = imageCount;
-	createInfo.imageFormat      = surfaceFormat.format;
-	createInfo.imageColorSpace  = surfaceFormat.colorSpace;
-	createInfo.imageExtent      = extent;
-	createInfo.imageArrayLayers = 1;
-	createInfo.imageUsage       = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+	vk::SwapchainCreateInfoKHR swapChainCreateInfo = {
+	    .surface          = device.surface(),
+	    .minImageCount    = imageCount,
+	    .imageFormat      = swapChainSurfaceFormat.format,
+	    .imageColorSpace  = swapChainSurfaceFormat.colorSpace,
+	    .imageExtent      = swapChainExtent,
+	    .imageArrayLayers = 1,
+	    .imageUsage       = vk::ImageUsageFlagBits::eColorAttachment,
+	    .imageSharingMode = vk::SharingMode::eExclusive,
+	    .preTransform     = swapChainSupport.capabilities.currentTransform,
+	    .compositeAlpha   = vk::CompositeAlphaFlagBitsKHR::eOpaque,
+	    .presentMode      = presentMode,
+	    .clipped          = true};
 
 	QueueFamilyIndices indices              = device.findPhysicalQueueFamilies();
 	uint32_t           queueFamilyIndices[] = {indices.graphicsFamily.value(), indices.presentFamily.value()};
 
 	if (indices.graphicsFamily != indices.presentFamily) {
-		createInfo.imageSharingMode      = VK_SHARING_MODE_CONCURRENT;
-		createInfo.queueFamilyIndexCount = 2;
-		createInfo.pQueueFamilyIndices   = queueFamilyIndices;
+		swapChainCreateInfo.imageSharingMode      = vk::SharingMode::eConcurrent;
+		swapChainCreateInfo.queueFamilyIndexCount = 2;
+		swapChainCreateInfo.pQueueFamilyIndices   = queueFamilyIndices;
 	} else {
-		createInfo.imageSharingMode      = VK_SHARING_MODE_EXCLUSIVE;
-		createInfo.queueFamilyIndexCount = 0;              // Optional
-		createInfo.pQueueFamilyIndices   = nullptr;        // Optional
+		swapChainCreateInfo.imageSharingMode      = vk::SharingMode::eExclusive;
+		swapChainCreateInfo.queueFamilyIndexCount = 0;              // Optional
+		swapChainCreateInfo.pQueueFamilyIndices   = nullptr;        // Optional
 	}
 
-	createInfo.preTransform   = swapChainSupport.capabilities.currentTransform;
-	createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-
-	createInfo.presentMode = presentMode;
-	createInfo.clipped     = VK_TRUE;
-
-	createInfo.oldSwapchain = VK_NULL_HANDLE;
-
-	if (vkCreateSwapchainKHR(device.device(), &createInfo, nullptr, &swapChain) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create swap chain!");
-	}
-
-	// we only specified a minimum number of images in the swap chain, so the implementation is
-	// allowed to create a swap chain with more. That's why we'll first query the final number of
-	// images with vkGetSwapchainImagesKHR, then resize the container and finally call it again to
-	// retrieve the handles.
-	vkGetSwapchainImagesKHR(device.device(), swapChain, &imageCount, nullptr);
-	swapChainImages.resize(imageCount);
-	vkGetSwapchainImagesKHR(device.device(), swapChain, &imageCount, swapChainImages.data());
-
-	swapChainImageFormat = surfaceFormat.format;
-	swapChainExtent      = extent;
+	swapChain       = vk::raii::SwapchainKHR(device.device(), swapChainCreateInfo);
+	swapChainImages = swapChain.getImages();
 }
 
 void SwapChain::createImageViews()
@@ -194,14 +170,14 @@ void SwapChain::createImageViews()
 		viewInfo.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
 		viewInfo.image                           = swapChainImages[i];
 		viewInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-		viewInfo.format                          = swapChainImageFormat;
+		viewInfo.format                          = static_cast<VkFormat>(swapChainSurfaceFormat.format);
 		viewInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
 		viewInfo.subresourceRange.baseMipLevel   = 0;
 		viewInfo.subresourceRange.levelCount     = 1;
 		viewInfo.subresourceRange.baseArrayLayer = 0;
 		viewInfo.subresourceRange.layerCount     = 1;
 
-		if (vkCreateImageView(device.device(), &viewInfo, nullptr, &swapChainImageViews[i]) !=
+		if (vkCreateImageView(*device.device(), &viewInfo, nullptr, &swapChainImageViews[i]) !=
 		    VK_SUCCESS) {
 			throw std::runtime_error("failed to create texture image view!");
 		}
@@ -225,7 +201,7 @@ void SwapChain::createRenderPass()
 	depthAttachmentRef.layout     = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
 	VkAttachmentDescription colorAttachment = {};
-	colorAttachment.format                  = getSwapChainImageFormat();
+	colorAttachment.format                  = getSwapChainSurfaceFormat();
 	colorAttachment.samples                 = VK_SAMPLE_COUNT_1_BIT;
 	colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_CLEAR;
 	colorAttachment.storeOp                 = VK_ATTACHMENT_STORE_OP_STORE;
@@ -265,7 +241,7 @@ void SwapChain::createRenderPass()
 	renderPassInfo.dependencyCount                        = 1;
 	renderPassInfo.pDependencies                          = &dependency;
 
-	if (vkCreateRenderPass(device.device(), &renderPassInfo, nullptr, &renderPass) != VK_SUCCESS) {
+	if (vkCreateRenderPass(*device.device(), &renderPassInfo, nullptr, &renderPass) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create render pass!");
 	}
 }
@@ -287,7 +263,7 @@ void SwapChain::createFramebuffers()
 		framebufferInfo.layers                  = 1;
 
 		if (vkCreateFramebuffer(
-		        device.device(),
+		        *device.device(),
 		        &framebufferInfo,
 		        nullptr,
 		        &swapChainFramebuffers[i]) != VK_SUCCESS) {
@@ -339,7 +315,7 @@ void SwapChain::createDepthResources()
 		viewInfo.subresourceRange.baseArrayLayer = 0;
 		viewInfo.subresourceRange.layerCount     = 1;
 
-		if (vkCreateImageView(device.device(), &viewInfo, nullptr, &depthImageViews[i]) != VK_SUCCESS) {
+		if (vkCreateImageView(*device.device(), &viewInfo, nullptr, &depthImageViews[i]) != VK_SUCCESS) {
 			throw std::runtime_error("failed to create texture image view!");
 		}
 	}
@@ -360,70 +336,70 @@ void SwapChain::createSyncObjects()
 	fenceInfo.flags             = VK_FENCE_CREATE_SIGNALED_BIT;
 
 	for (size_t i = 0; i < imageCount(); i++) {
-		if (vkCreateSemaphore(device.device(), &semaphoreInfo, nullptr, &renderFinishedSemaphores[i]) !=
+		if (vkCreateSemaphore(*device.device(), &semaphoreInfo, nullptr, &renderFinishedSemaphores[i]) !=
 		    VK_SUCCESS) {
 			throw std::runtime_error("failed to create synchronization objects for a frame!");
 		}
 	}
 
 	for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-		if (vkCreateSemaphore(device.device(), &semaphoreInfo, nullptr, &imageAvailableSemaphores[i]) !=
+		if (vkCreateSemaphore(*device.device(), &semaphoreInfo, nullptr, &imageAvailableSemaphores[i]) !=
 		        VK_SUCCESS ||
-		    vkCreateFence(device.device(), &fenceInfo, nullptr, &inFlightFences[i]) != VK_SUCCESS) {
+		    vkCreateFence(*device.device(), &fenceInfo, nullptr, &inFlightFences[i]) != VK_SUCCESS) {
 			throw std::runtime_error("failed to create synchronization objects for a frame!");
 		}
 	}
 }
 
-VkSurfaceFormatKHR SwapChain::chooseSwapSurfaceFormat(
-    const std::vector<VkSurfaceFormatKHR> &availableFormats)
+vk::SurfaceFormatKHR SwapChain::chooseSwapSurfaceFormat(
+    std::vector<vk::SurfaceFormatKHR> const &availableFormats)
 {
-	for (const auto &availableFormat : availableFormats) {
-		if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB &&
-		    availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
-			return availableFormat;
-		}
-	}
-
-	return availableFormats[0];
+	assert(!availableFormats.empty());
+	const auto formatIt = std::ranges::find_if(availableFormats, [](const auto &format) {
+		return format.format == vk::Format::eB8G8R8A8Srgb &&
+		       format.colorSpace == vk::ColorSpaceKHR::eSrgbNonlinear;
+	});
+	return formatIt != availableFormats.end() ? *formatIt : availableFormats[0];
 }
 
-VkPresentModeKHR SwapChain::chooseSwapPresentMode(
-    const std::vector<VkPresentModeKHR> &availablePresentModes)
+vk::PresentModeKHR SwapChain::chooseSwapPresentMode(
+    const std::vector<vk::PresentModeKHR> &availablePresentModes)
 {
-	for (const auto &availablePresentMode : availablePresentModes) {
-		if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
-			std::cout << "Present mode: Mailbox" << std::endl;
-			return availablePresentMode;
-		}
-	}
+	assert(std::ranges::any_of(availablePresentModes, [](const auto &presentMode) {
+		return presentMode == vk::PresentModeKHR::eFifo;
+	}));
 
-	// for (const auto &availablePresentMode : availablePresentModes) {
-	//   if (availablePresentMode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
-	//     std::cout << "Present mode: Immediate" << std::endl;
-	//     return availablePresentMode;
-	//   }
-	// }
-
-	std::cout << "Present mode: V-Sync" << std::endl;
-	return VK_PRESENT_MODE_FIFO_KHR;
+	return std::ranges::any_of(availablePresentModes, [](const auto &presentMode) {
+		return presentMode == vk::PresentModeKHR::eMailbox;
+	}) ?
+	           vk::PresentModeKHR::eMailbox :
+	           vk::PresentModeKHR::eFifo;
 }
 
-VkExtent2D SwapChain::chooseSwapExtent(const VkSurfaceCapabilitiesKHR &capabilities)
+vk::Extent2D SwapChain::chooseSwapExtent(const vk::SurfaceCapabilitiesKHR &capabilities)
 {
 	if (capabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
 		return capabilities.currentExtent;
-	} else {
-		VkExtent2D actualExtent = windowExtent;
-		actualExtent.width      = std::max(
-            capabilities.minImageExtent.width,
-            std::min(capabilities.maxImageExtent.width, actualExtent.width));
-		actualExtent.height = std::max(
-		    capabilities.minImageExtent.height,
-		    std::min(capabilities.maxImageExtent.height, actualExtent.height));
-
-		return actualExtent;
 	}
+
+	int width, height;
+	device.getWindow().getFrameBufferSize(&width, &height);
+	// TODO: This implementation violates the Law of Demeter.
+
+	return {
+	    std::clamp<uint32_t>(width, capabilities.minImageExtent.width, capabilities.maxImageExtent.width),
+	    std::clamp<uint32_t>(height, capabilities.minImageExtent.height, capabilities.maxImageExtent.height),
+	};
+}
+
+uint32_t SwapChain::chooseSwapMinImageCount(const vk::SurfaceCapabilitiesKHR &capabilities)
+{
+	auto minImageCount = std::max(3u, capabilities.minImageCount);
+	if (capabilities.maxImageCount > 0 && minImageCount > capabilities.maxImageCount) {
+		return capabilities.maxImageCount;
+	}
+
+	return minImageCount;
 }
 
 VkFormat SwapChain::findDepthFormat()

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -1,5 +1,4 @@
 #include "swap_chain.h"
-#include "vulkan/vulkan.hpp"
 
 // std
 #include <algorithm>
@@ -13,6 +12,8 @@
 
 namespace mvr
 {
+
+// Constructor & Destructor
 
 SwapChain::SwapChain(VulkanDevice &device, VkExtent2D windowExtent) : device{device}, windowExtent{windowExtent}
 {
@@ -53,6 +54,8 @@ SwapChain::~SwapChain()
 	}
 }
 
+// Public Methods
+
 VkResult SwapChain::acquireNextImage(uint32_t *imageIndex)
 {
 	vkWaitForFences(
@@ -73,8 +76,7 @@ VkResult SwapChain::acquireNextImage(uint32_t *imageIndex)
 	return result;
 }
 
-VkResult SwapChain::submitCommandBuffers(
-    const VkCommandBuffer *buffers, uint32_t *imageIndex)
+VkResult SwapChain::submitCommandBuffers(const VkCommandBuffer *buffers, uint32_t *imageIndex)
 {
 	if (imagesInFlight[*imageIndex] != VK_NULL_HANDLE) {
 		vkWaitForFences(*device.device(), 1, &imagesInFlight[*imageIndex], VK_TRUE, UINT64_MAX);
@@ -122,6 +124,16 @@ VkResult SwapChain::submitCommandBuffers(
 	return result;
 }
 
+VkFormat SwapChain::findDepthFormat()
+{
+	return device.findSupportedFormat(
+	    {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT},
+	    VK_IMAGE_TILING_OPTIMAL,
+	    VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
+}
+
+// Private Init Methods
+
 void SwapChain::createSwapChain()
 {
 	SwapChainSupportDetails swapChainSupport = device.getSwapChainSupport();
@@ -149,13 +161,8 @@ void SwapChain::createSwapChain()
 	uint32_t           queueFamilyIndices[] = {indices.graphicsFamily.value(), indices.presentFamily.value()};
 
 	if (indices.graphicsFamily != indices.presentFamily) {
-		swapChainCreateInfo.imageSharingMode      = vk::SharingMode::eConcurrent;
-		swapChainCreateInfo.queueFamilyIndexCount = 2;
-		swapChainCreateInfo.pQueueFamilyIndices   = queueFamilyIndices;
-	} else {
-		swapChainCreateInfo.imageSharingMode      = vk::SharingMode::eExclusive;
-		swapChainCreateInfo.queueFamilyIndexCount = 0;              // Optional
-		swapChainCreateInfo.pQueueFamilyIndices   = nullptr;        // Optional
+		swapChainCreateInfo.imageSharingMode    = vk::SharingMode::eConcurrent;
+		swapChainCreateInfo.pQueueFamilyIndices = queueFamilyIndices;
 	}
 
 	swapChain       = vk::raii::SwapchainKHR(device.device(), swapChainCreateInfo);
@@ -246,32 +253,6 @@ void SwapChain::createRenderPass()
 	}
 }
 
-void SwapChain::createFramebuffers()
-{
-	swapChainFramebuffers.resize(imageCount());
-	for (size_t i = 0; i < imageCount(); i++) {
-		std::array<VkImageView, 2> attachments = {swapChainImageViews[i], depthImageViews[i]};
-
-		VkExtent2D              swapChainExtent = getSwapChainExtent();
-		VkFramebufferCreateInfo framebufferInfo = {};
-		framebufferInfo.sType                   = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		framebufferInfo.renderPass              = renderPass;
-		framebufferInfo.attachmentCount         = static_cast<uint32_t>(attachments.size());
-		framebufferInfo.pAttachments            = attachments.data();
-		framebufferInfo.width                   = swapChainExtent.width;
-		framebufferInfo.height                  = swapChainExtent.height;
-		framebufferInfo.layers                  = 1;
-
-		if (vkCreateFramebuffer(
-		        *device.device(),
-		        &framebufferInfo,
-		        nullptr,
-		        &swapChainFramebuffers[i]) != VK_SUCCESS) {
-			throw std::runtime_error("failed to create framebuffer!");
-		}
-	}
-}
-
 void SwapChain::createDepthResources()
 {
 	VkFormat   depthFormat     = findDepthFormat();
@@ -321,6 +302,32 @@ void SwapChain::createDepthResources()
 	}
 }
 
+void SwapChain::createFramebuffers()
+{
+	swapChainFramebuffers.resize(imageCount());
+	for (size_t i = 0; i < imageCount(); i++) {
+		std::array<VkImageView, 2> attachments = {swapChainImageViews[i], depthImageViews[i]};
+
+		VkExtent2D              swapChainExtent = getSwapChainExtent();
+		VkFramebufferCreateInfo framebufferInfo = {};
+		framebufferInfo.sType                   = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+		framebufferInfo.renderPass              = renderPass;
+		framebufferInfo.attachmentCount         = static_cast<uint32_t>(attachments.size());
+		framebufferInfo.pAttachments            = attachments.data();
+		framebufferInfo.width                   = swapChainExtent.width;
+		framebufferInfo.height                  = swapChainExtent.height;
+		framebufferInfo.layers                  = 1;
+
+		if (vkCreateFramebuffer(
+		        *device.device(),
+		        &framebufferInfo,
+		        nullptr,
+		        &swapChainFramebuffers[i]) != VK_SUCCESS) {
+			throw std::runtime_error("failed to create framebuffer!");
+		}
+	}
+}
+
 void SwapChain::createSyncObjects()
 {
 	imageAvailableSemaphores.resize(MAX_FRAMES_IN_FLIGHT);
@@ -350,6 +357,8 @@ void SwapChain::createSyncObjects()
 		}
 	}
 }
+
+// Helper Methods
 
 vk::SurfaceFormatKHR SwapChain::chooseSwapSurfaceFormat(
     std::vector<vk::SurfaceFormatKHR> const &availableFormats)
@@ -400,14 +409,6 @@ uint32_t SwapChain::chooseSwapMinImageCount(const vk::SurfaceCapabilitiesKHR &ca
 	}
 
 	return minImageCount;
-}
-
-VkFormat SwapChain::findDepthFormat()
-{
-	return device.findSupportedFormat(
-	    {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT},
-	    VK_IMAGE_TILING_OPTIMAL,
-	    VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
 }
 
 }        // namespace mvr

--- a/src/core/swap_chain.cpp
+++ b/src/core/swap_chain.cpp
@@ -150,7 +150,7 @@ void SwapChain::createSwapChain()
 	createInfo.imageUsage       = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
 	QueueFamilyIndices indices              = device.findPhysicalQueueFamilies();
-	uint32_t           queueFamilyIndices[] = {indices.graphicsFamily, indices.presentFamily};
+	uint32_t           queueFamilyIndices[] = {indices.graphicsFamily.value(), indices.presentFamily.value()};
 
 	if (indices.graphicsFamily != indices.presentFamily) {
 		createInfo.imageSharingMode      = VK_SHARING_MODE_CONCURRENT;

--- a/src/core/swap_chain.h
+++ b/src/core/swap_chain.h
@@ -34,9 +34,13 @@ class SwapChain
 	{
 		return renderPass;
 	}
-	VkImageView getImageView(int index)
+	vk::Image getImage(uint32_t index)
 	{
-		return *swapChainImageViews[index];
+		return swapChainImages[index];
+	}
+	vk::raii::ImageView &getImageView(uint32_t index)
+	{
+		return swapChainImageViews[index];
 	}
 	size_t imageCount()
 	{
@@ -46,21 +50,27 @@ class SwapChain
 	{
 		return swapChainSurfaceFormat.format;
 	}
-	VkExtent2D getSwapChainExtent()
+	vk::Extent2D getSwapChainExtent()
 	{
 		return swapChainExtent;
-	}
-	uint32_t width()
-	{
-		return swapChainExtent.width;
-	}
-	uint32_t height()
-	{
-		return swapChainExtent.height;
 	}
 	float extentAspectRatio()
 	{
 		return static_cast<float>(swapChainExtent.width) / static_cast<float>(swapChainExtent.height);
+	}
+	vk::Viewport getViewport()
+	{
+		return vk::Viewport(
+		    0.0f,
+		    0.0f,
+		    static_cast<float>(swapChainExtent.width),
+		    static_cast<float>(swapChainExtent.height),
+		    0.0f,
+		    1.0f);
+	}
+	vk::Rect2D getScissor()
+	{
+		return vk::Rect2D(vk::Offset2D{0, 0}, swapChainExtent);
 	}
 
   private:

--- a/src/core/swap_chain.h
+++ b/src/core/swap_chain.h
@@ -36,7 +36,7 @@ class SwapChain
 	}
 	VkImageView getImageView(int index)
 	{
-		return swapChainImageViews[index];
+		return *swapChainImageViews[index];
 	}
 	size_t imageCount()
 	{
@@ -74,8 +74,8 @@ class SwapChain
 
 	vk::raii::SwapchainKHR swapChain = nullptr;
 
-	std::vector<vk::Image>   swapChainImages;
-	std::vector<VkImageView> swapChainImageViews;
+	std::vector<vk::Image>           swapChainImages;
+	std::vector<vk::raii::ImageView> swapChainImageViews;
 
 	VkRenderPass renderPass;
 

--- a/src/core/swap_chain.h
+++ b/src/core/swap_chain.h
@@ -42,9 +42,9 @@ class SwapChain
 	{
 		return swapChainImages.size();
 	}
-	VkFormat getSwapChainSurfaceFormat()
+	vk::Format getSwapChainSurfaceFormat()
 	{
-		return static_cast<VkFormat>(swapChainSurfaceFormat.format);
+		return swapChainSurfaceFormat.format;
 	}
 	VkExtent2D getSwapChainExtent()
 	{

--- a/src/core/swap_chain.h
+++ b/src/core/swap_chain.h
@@ -13,12 +13,19 @@ class SwapChain
   public:
 	static constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
+	// Constructor & Destructor
 	SwapChain(VulkanDevice &deviceRef, VkExtent2D windowExtent);
 	~SwapChain();
 
 	SwapChain(const SwapChain &)      = delete;
 	void operator=(const SwapChain &) = delete;
 
+	// Public Methods
+	VkResult acquireNextImage(uint32_t *imageIndex);
+	VkResult submitCommandBuffers(const VkCommandBuffer *buffers, uint32_t *imageIndex);
+	VkFormat findDepthFormat();
+
+	// Getters
 	VkFramebuffer getFrameBuffer(int index)
 	{
 		return swapChainFramebuffers[index];
@@ -51,54 +58,51 @@ class SwapChain
 	{
 		return swapChainExtent.height;
 	}
-
 	float extentAspectRatio()
 	{
 		return static_cast<float>(swapChainExtent.width) / static_cast<float>(swapChainExtent.height);
 	}
-	VkFormat findDepthFormat();
-
-	VkResult acquireNextImage(uint32_t *imageIndex);
-	VkResult submitCommandBuffers(const VkCommandBuffer *buffers, uint32_t *imageIndex);
 
   private:
-	void createSwapChain();
-	void createImageViews();
-	void createDepthResources();
-	void createRenderPass();
-	void createFramebuffers();
-	void createSyncObjects();
-
-	// Helper functions
-	vk::SurfaceFormatKHR chooseSwapSurfaceFormat(
-	    std::vector<vk::SurfaceFormatKHR> const &availableFormats);
-	vk::PresentModeKHR chooseSwapPresentMode(
-	    const std::vector<vk::PresentModeKHR> &availablePresentModes);
-	vk::Extent2D chooseSwapExtent(const vk::SurfaceCapabilitiesKHR &capabilities);
-	uint32_t     chooseSwapMinImageCount(const vk::SurfaceCapabilitiesKHR &capabilities);
-
+	// Variables
 	VulkanDevice &device;
 	VkExtent2D    windowExtent;
 
-	vk::raii::SwapchainKHR swapChain = nullptr;
-
 	vk::SurfaceFormatKHR swapChainSurfaceFormat;
 	vk::Extent2D         swapChainExtent;
+	size_t               currentFrame = 0;
 
-	std::vector<VkFramebuffer> swapChainFramebuffers;
-	VkRenderPass               renderPass;
+	vk::raii::SwapchainKHR swapChain = nullptr;
+
+	std::vector<vk::Image>   swapChainImages;
+	std::vector<VkImageView> swapChainImageViews;
+
+	VkRenderPass renderPass;
 
 	std::vector<VkImage>        depthImages;
 	std::vector<VkDeviceMemory> depthImageMemorys;
 	std::vector<VkImageView>    depthImageViews;
-	std::vector<vk::Image>      swapChainImages;
-	std::vector<VkImageView>    swapChainImageViews;
+
+	std::vector<VkFramebuffer> swapChainFramebuffers;
 
 	std::vector<VkSemaphore> imageAvailableSemaphores;
 	std::vector<VkSemaphore> renderFinishedSemaphores;
 	std::vector<VkFence>     inFlightFences;
 	std::vector<VkFence>     imagesInFlight;
-	size_t                   currentFrame = 0;
+
+	// Private Init Methods
+	void createSwapChain();
+	void createImageViews();
+	void createRenderPass();
+	void createDepthResources();
+	void createFramebuffers();
+	void createSyncObjects();
+
+	// Helper Methods
+	vk::SurfaceFormatKHR chooseSwapSurfaceFormat(const std::vector<vk::SurfaceFormatKHR> &availableFormats);
+	vk::PresentModeKHR   chooseSwapPresentMode(const std::vector<vk::PresentModeKHR> &availablePresentModes);
+	vk::Extent2D         chooseSwapExtent(const vk::SurfaceCapabilitiesKHR &capabilities);
+	uint32_t             chooseSwapMinImageCount(const vk::SurfaceCapabilitiesKHR &capabilities);
 };
 
 }        // namespace mvr

--- a/src/core/swap_chain.h
+++ b/src/core/swap_chain.h
@@ -52,17 +52,21 @@ class SwapChain
 	}
 	vk::Viewport getViewport()
 	{
-		return vk::Viewport(
-		    0.0f,
-		    0.0f,
-		    static_cast<float>(swapChainExtent.width),
-		    static_cast<float>(swapChainExtent.height),
-		    0.0f,
-		    1.0f);
+		return vk::Viewport{
+		    .x        = 0.0f,
+		    .y        = 0.0f,
+		    .width    = static_cast<float>(swapChainExtent.width),
+		    .height   = static_cast<float>(swapChainExtent.height),
+		    .minDepth = 0.0f,
+		    .maxDepth = 1.0f,
+		};
 	}
 	vk::Rect2D getScissor()
 	{
-		return vk::Rect2D(vk::Offset2D{0, 0}, swapChainExtent);
+		return vk::Rect2D{
+		    .offset = {0, 0},
+		    .extent = swapChainExtent,
+		};
 	}
 
   private:

--- a/src/core/swap_chain.h
+++ b/src/core/swap_chain.h
@@ -2,11 +2,7 @@
 
 #include "vulkan_device.h"
 
-// vulkan headers
-#include <vulkan/vulkan.h>
-
 // std
-#include <string>
 #include <vector>
 
 namespace mvr
@@ -39,9 +35,9 @@ class SwapChain
 	{
 		return swapChainImages.size();
 	}
-	VkFormat getSwapChainImageFormat()
+	VkFormat getSwapChainSurfaceFormat()
 	{
-		return swapChainImageFormat;
+		return static_cast<VkFormat>(swapChainSurfaceFormat.format);
 	}
 	VkExtent2D getSwapChainExtent()
 	{
@@ -74,14 +70,20 @@ class SwapChain
 	void createSyncObjects();
 
 	// Helper functions
-	VkSurfaceFormatKHR chooseSwapSurfaceFormat(
-	    const std::vector<VkSurfaceFormatKHR> &availableFormats);
-	VkPresentModeKHR chooseSwapPresentMode(
-	    const std::vector<VkPresentModeKHR> &availablePresentModes);
-	VkExtent2D chooseSwapExtent(const VkSurfaceCapabilitiesKHR &capabilities);
+	vk::SurfaceFormatKHR chooseSwapSurfaceFormat(
+	    std::vector<vk::SurfaceFormatKHR> const &availableFormats);
+	vk::PresentModeKHR chooseSwapPresentMode(
+	    const std::vector<vk::PresentModeKHR> &availablePresentModes);
+	vk::Extent2D chooseSwapExtent(const vk::SurfaceCapabilitiesKHR &capabilities);
+	uint32_t     chooseSwapMinImageCount(const vk::SurfaceCapabilitiesKHR &capabilities);
 
-	VkFormat   swapChainImageFormat;
-	VkExtent2D swapChainExtent;
+	VulkanDevice &device;
+	VkExtent2D    windowExtent;
+
+	vk::raii::SwapchainKHR swapChain = nullptr;
+
+	vk::SurfaceFormatKHR swapChainSurfaceFormat;
+	vk::Extent2D         swapChainExtent;
 
 	std::vector<VkFramebuffer> swapChainFramebuffers;
 	VkRenderPass               renderPass;
@@ -89,13 +91,8 @@ class SwapChain
 	std::vector<VkImage>        depthImages;
 	std::vector<VkDeviceMemory> depthImageMemorys;
 	std::vector<VkImageView>    depthImageViews;
-	std::vector<VkImage>        swapChainImages;
+	std::vector<vk::Image>      swapChainImages;
 	std::vector<VkImageView>    swapChainImageViews;
-
-	VulkanDevice &device;
-	VkExtent2D    windowExtent;
-
-	VkSwapchainKHR swapChain;
 
 	std::vector<VkSemaphore> imageAvailableSemaphores;
 	std::vector<VkSemaphore> renderFinishedSemaphores;

--- a/src/core/swap_chain.h
+++ b/src/core/swap_chain.h
@@ -3,6 +3,7 @@
 #include "vulkan_device.h"
 
 // std
+#include <utility>
 #include <vector>
 
 namespace mvr
@@ -21,19 +22,10 @@ class SwapChain
 	void operator=(const SwapChain &) = delete;
 
 	// Public Methods
-	VkResult acquireNextImage(uint32_t *imageIndex);
-	VkResult submitCommandBuffers(const VkCommandBuffer *buffers, uint32_t *imageIndex);
-	VkFormat findDepthFormat();
+	std::pair<vk::Result, uint32_t> acquireNextImage(uint32_t frameIndex);
+	vk::Result                      submitCommandBuffers(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex, uint32_t frameIndex);
+	VkFormat                        findDepthFormat();
 
-	// Getters
-	VkFramebuffer getFrameBuffer(int index)
-	{
-		return swapChainFramebuffers[index];
-	}
-	VkRenderPass getRenderPass()
-	{
-		return renderPass;
-	}
 	vk::Image getImage(uint32_t index)
 	{
 		return swapChainImages[index];
@@ -80,32 +72,24 @@ class SwapChain
 
 	vk::SurfaceFormatKHR swapChainSurfaceFormat;
 	vk::Extent2D         swapChainExtent;
-	size_t               currentFrame = 0;
 
 	vk::raii::SwapchainKHR swapChain = nullptr;
 
 	std::vector<vk::Image>           swapChainImages;
 	std::vector<vk::raii::ImageView> swapChainImageViews;
 
-	VkRenderPass renderPass;
-
 	std::vector<VkImage>        depthImages;
 	std::vector<VkDeviceMemory> depthImageMemorys;
 	std::vector<VkImageView>    depthImageViews;
 
-	std::vector<VkFramebuffer> swapChainFramebuffers;
-
-	std::vector<VkSemaphore> imageAvailableSemaphores;
-	std::vector<VkSemaphore> renderFinishedSemaphores;
-	std::vector<VkFence>     inFlightFences;
-	std::vector<VkFence>     imagesInFlight;
+	std::vector<vk::raii::Semaphore> renderFinishedSemaphores;
+	std::vector<vk::raii::Semaphore> imageAvailableSemaphores;
+	std::vector<vk::raii::Fence>     inFlightFences;
 
 	// Private Init Methods
 	void createSwapChain();
 	void createImageViews();
-	void createRenderPass();
 	void createDepthResources();
-	void createFramebuffers();
 	void createSyncObjects();
 
 	// Helper Methods

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -1,4 +1,5 @@
 #include "vulkan_device.h"
+#include "vulkan/vulkan.hpp"
 
 // std
 #include <algorithm>
@@ -28,11 +29,6 @@ VulkanDevice::VulkanDevice(Window &window) :
 		std::cerr << "VulkanDevice initialization aborted: " << e.what() << std::endl;
 		throw;
 	}
-}
-
-VulkanDevice::~VulkanDevice()
-{
-	vkDestroyCommandPool(*device_, commandPool, nullptr);
 }
 
 // Public Methods
@@ -105,7 +101,7 @@ VkCommandBuffer VulkanDevice::beginSingleTimeCommands()
 	VkCommandBufferAllocateInfo allocInfo{};
 	allocInfo.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
 	allocInfo.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-	allocInfo.commandPool        = commandPool;
+	allocInfo.commandPool        = *commandPool;
 	allocInfo.commandBufferCount = 1;
 
 	VkCommandBuffer commandBuffer;
@@ -131,7 +127,7 @@ void VulkanDevice::endSingleTimeCommands(VkCommandBuffer commandBuffer)
 	vkQueueSubmit(*graphicsQueue_, 1, &submitInfo, VK_NULL_HANDLE);
 	vkQueueWaitIdle(*graphicsQueue_);
 
-	vkFreeCommandBuffers(*device_, commandPool, 1, &commandBuffer);
+	vkFreeCommandBuffers(*device_, *commandPool, 1, &commandBuffer);
 }
 
 void VulkanDevice::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size)
@@ -335,17 +331,12 @@ void VulkanDevice::createLogicalDevice()
 
 void VulkanDevice::createCommandPool()
 {
-	QueueFamilyIndices queueFamilyIndices = findPhysicalQueueFamilies();
+	vk::CommandPoolCreateInfo poolInfo = {
+	    .flags            = vk::CommandPoolCreateFlagBits::eResetCommandBuffer,
+	    .queueFamilyIndex = queueFamilyIndices.graphicsFamily.value(),
+	};
 
-	VkCommandPoolCreateInfo poolInfo = {};
-	poolInfo.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-	poolInfo.queueFamilyIndex        = queueFamilyIndices.graphicsFamily.value();
-	poolInfo.flags =
-	    VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-
-	if (vkCreateCommandPool(*device_, &poolInfo, nullptr, &commandPool) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create command pool!");
-	}
+	commandPool = vk::raii::CommandPool(device_, poolInfo);
 }
 
 // Helper Methods

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -28,7 +28,7 @@ VulkanDevice::VulkanDevice(Window &window) :
 		pickPhysicalDevice();
 		createLogicalDevice();
 		createCommandPool();
-	} catch (const std::runtime_error &e) {
+	} catch (const std::exception &e) {
 		std::cerr << "VulkanDevice initialization aborted: " << e.what() << std::endl;
 		throw;
 	}
@@ -280,7 +280,7 @@ void VulkanDevice::pickPhysicalDevice()
 	std::cout << "Device count: " << physicalDevices.size() << std::endl;
 	for (const auto &device : physicalDevices) {
 		auto props = device.getProperties();
-		std::cout << "Physical device: " << props.deviceName
+		std::cout << "Available GPUs: " << props.deviceName
 		          << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
 	}
 
@@ -293,6 +293,9 @@ void VulkanDevice::pickPhysicalDevice()
 	} else {
 		physicalDevice     = *it;
 		queueFamilyIndices = findQueueFamilies(physicalDevice);
+
+		vk::PhysicalDeviceProperties deviceProperties = physicalDevice.getProperties();
+		std::cout << "Selected GPU: " << deviceProperties.deviceName << std::endl;
 	}
 
 	// TODO: Implement a scoring system to select the most suitable GPU.

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -33,10 +33,9 @@ VulkanDevice::VulkanDevice(Window &window) :
 
 // Public Methods
 
-uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
+uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, vk::MemoryPropertyFlags properties)
 {
-	VkPhysicalDeviceMemoryProperties memProperties;
-	vkGetPhysicalDeviceMemoryProperties(*physicalDevice, &memProperties);
+	vk::PhysicalDeviceMemoryProperties memProperties = physicalDevice.getMemoryProperties();
 	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
 		if ((typeFilter & (1 << i)) &&
 		    (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
@@ -62,38 +61,6 @@ VkFormat VulkanDevice::findSupportedFormat(
 		}
 	}
 	throw std::runtime_error("failed to find supported format!");
-}
-
-void VulkanDevice::createBuffer(
-    VkDeviceSize          size,
-    VkBufferUsageFlags    usage,
-    VkMemoryPropertyFlags properties,
-    VkBuffer             &buffer,
-    VkDeviceMemory       &bufferMemory)
-{
-	VkBufferCreateInfo bufferInfo{};
-	bufferInfo.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-	bufferInfo.size        = size;
-	bufferInfo.usage       = usage;
-	bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-	if (vkCreateBuffer(*device_, &bufferInfo, nullptr, &buffer) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create vertex buffer!");
-	}
-
-	VkMemoryRequirements memRequirements;
-	vkGetBufferMemoryRequirements(*device_, buffer, &memRequirements);
-
-	VkMemoryAllocateInfo allocInfo{};
-	allocInfo.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	allocInfo.allocationSize  = memRequirements.size;
-	allocInfo.memoryTypeIndex = findMemoryType(memRequirements.memoryTypeBits, properties);
-
-	if (vkAllocateMemory(*device_, &allocInfo, nullptr, &bufferMemory) != VK_SUCCESS) {
-		throw std::runtime_error("failed to allocate vertex buffer memory!");
-	}
-
-	vkBindBufferMemory(*device_, buffer, bufferMemory, 0);
 }
 
 VkCommandBuffer VulkanDevice::beginSingleTimeCommands()
@@ -173,7 +140,7 @@ void VulkanDevice::copyBufferToImage(
 
 void VulkanDevice::createImageWithInfo(
     const VkImageCreateInfo &imageInfo,
-    VkMemoryPropertyFlags    properties,
+    vk::MemoryPropertyFlags  properties,
     VkImage                 &image,
     VkDeviceMemory          &imageMemory)
 {

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <iostream>
 #include <set>
+#include <string_view>
 #include <vector>
 
 namespace mvr
@@ -407,7 +408,7 @@ std::vector<const char *> VulkanDevice::getRequiredLayers()
 	// Check if the required layers are supported by the Vulkan implementation.
 	auto it = std::ranges::find_if(requiredLayers, [&](auto const &req) {
 		return std::ranges::none_of(supportedLayers, [&](auto const &prop) {
-			return strcmp(prop.layerName, req) == 0;
+			return std::string_view(prop.layerName) == req;
 		});
 	});
 
@@ -448,7 +449,7 @@ std::vector<const char *> VulkanDevice::getRequiredExtensions()
 	// Check if the required extensions are supported by the Vulkan implementation.
 	auto it = std::ranges::find_if(requiredExtensions, [&](auto const &req) {
 		return std::ranges::none_of(supportedExtensions, [&](auto const &prop) {
-			return strcmp(prop.extensionName, req) == 0;
+			return std::string_view(prop.extensionName) == req;
 		});
 	});
 

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -92,11 +92,10 @@ void VulkanDevice::createInstance()
 #if __APPLE__
 	flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKhr;
 #endif
-
 	// extensions
 	auto extensions = getRequiredExtensions();
 
-	// Check if the required GLFW extensions are supported by the Vulkan implementation.
+	// Verify and log required Vulkan instance extensions
 	hasGlfwRequiredInstanceExtensions();
 
 	vk::InstanceCreateInfo createInfo = {
@@ -305,18 +304,18 @@ std::vector<const char *> VulkanDevice::getRequiredExtensions()
 void VulkanDevice::hasGlfwRequiredInstanceExtensions()
 {
 	auto extensions = context.enumerateInstanceExtensionProperties();
-
 	std::cout << "available extensions:" << std::endl;
 	for (const auto &extension : extensions) {
 		std::cout << "\t" << extension.extensionName << std::endl;
 	}
 
-	std::cout << "required extensions:" << std::endl;
 	auto requiredExtensions = getRequiredExtensions();
+	std::cout << "required extensions:" << std::endl;
 	for (const auto &required : requiredExtensions) {
 		std::cout << "\t" << required << std::endl;
 	}
 
+	// Check if the required GLFW extensions are supported by the Vulkan implementation.
 	for (const auto &required : requiredExtensions) {
 		if (std::ranges::none_of(extensions,
 		                         [required](auto const &extension) {

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <set>
 #include <unordered_set>
+#include <vulkan/vulkan.hpp>
 
 namespace mvr
 {
@@ -68,11 +69,10 @@ VulkanDevice::~VulkanDevice()
 	vkDestroyDevice(device_, nullptr);
 
 	if (enableValidationLayers) {
-		DestroyDebugUtilsMessengerEXT(instance, debugMessenger, nullptr);
+		DestroyDebugUtilsMessengerEXT(*instance, debugMessenger, nullptr);
 	}
 
-	vkDestroySurfaceKHR(instance, surface_, nullptr);
-	vkDestroyInstance(instance, nullptr);
+	vkDestroySurfaceKHR(*instance, surface_, nullptr);
 }
 
 void VulkanDevice::createInstance()
@@ -81,20 +81,19 @@ void VulkanDevice::createInstance()
 		throw std::runtime_error("validation layers requested, but not available!");
 	}
 
-	VkApplicationInfo appInfo  = {};
-	appInfo.sType              = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-	appInfo.pApplicationName   = "LittleVulkanEngine App";
-	appInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
-	appInfo.pEngineName        = "No Engine";
-	appInfo.engineVersion      = VK_MAKE_VERSION(1, 0, 0);
-	appInfo.apiVersion         = VK_API_VERSION_1_0;
+	constexpr vk::ApplicationInfo appInfo{
+	    .pApplicationName   = "MyVulkanRenderer App",
+	    .applicationVersion = VK_MAKE_VERSION(1, 0, 0),
+	    .pEngineName        = "No Engine",
+	    .engineVersion      = VK_MAKE_VERSION(1, 0, 0),
+	    .apiVersion         = vk::ApiVersion14};
 
-	VkInstanceCreateInfo createInfo = {};
-	createInfo.sType                = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-	createInfo.pApplicationInfo     = &appInfo;
+	vk::InstanceCreateInfo createInfo = {
+	    .pApplicationInfo = &appInfo,
+	};
 
 #if __APPLE__
-	createInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+	createInfo.flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKhr;
 #endif
 
 	auto extensions                    = getRequiredExtensions();
@@ -113,9 +112,7 @@ void VulkanDevice::createInstance()
 		createInfo.pNext             = nullptr;
 	}
 
-	if (vkCreateInstance(&createInfo, nullptr, &instance) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create instance!");
-	}
+	instance = vk::raii::Instance(context, createInfo);
 
 	hasGflwRequiredInstanceExtensions();
 }
@@ -123,13 +120,13 @@ void VulkanDevice::createInstance()
 void VulkanDevice::pickPhysicalDevice()
 {
 	uint32_t deviceCount = 0;
-	vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
+	vkEnumeratePhysicalDevices(*instance, &deviceCount, nullptr);
 	if (deviceCount == 0) {
 		throw std::runtime_error("failed to find GPUs with Vulkan support!");
 	}
 	std::cout << "Device count: " << deviceCount << std::endl;
 	std::vector<VkPhysicalDevice> devices(deviceCount);
-	vkEnumeratePhysicalDevices(instance, &deviceCount, devices.data());
+	vkEnumeratePhysicalDevices(*instance, &deviceCount, devices.data());
 
 	for (const auto &device : devices) {
 		if (isDeviceSuitable(device)) {
@@ -210,7 +207,7 @@ void VulkanDevice::createCommandPool()
 
 void VulkanDevice::createSurface()
 {
-	window.createWindowSurface(instance, &surface_);
+	window.createWindowSurface(*instance, &surface_);
 }
 
 bool VulkanDevice::isDeviceSuitable(VkPhysicalDevice device)
@@ -252,7 +249,7 @@ void VulkanDevice::setupDebugMessenger()
 		return;
 	VkDebugUtilsMessengerCreateInfoEXT createInfo;
 	populateDebugMessengerCreateInfo(createInfo);
-	if (CreateDebugUtilsMessengerEXT(instance, &createInfo, nullptr, &debugMessenger) != VK_SUCCESS) {
+	if (CreateDebugUtilsMessengerEXT(*instance, &createInfo, nullptr, &debugMessenger) != VK_SUCCESS) {
 		throw std::runtime_error("failed to set up debug messenger!");
 	}
 }

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -1,4 +1,5 @@
 #include "vulkan_device.h"
+#include "vulkan/vulkan.hpp"
 
 // std
 #include <algorithm>
@@ -7,6 +8,7 @@
 #include <set>
 #include <string_view>
 #include <vector>
+#include <vulkan/vulkan.hpp>
 
 namespace mvr
 {
@@ -28,8 +30,7 @@ VulkanDevice::VulkanDevice(Window &window) :
 
 VulkanDevice::~VulkanDevice()
 {
-	vkDestroyCommandPool(device_, commandPool, nullptr);
-	vkDestroyDevice(device_, nullptr);
+	vkDestroyCommandPool(*device_, commandPool, nullptr);
 
 	vkDestroySurfaceKHR(*instance, surface_, nullptr);
 }
@@ -86,23 +87,23 @@ void VulkanDevice::createBuffer(
 	bufferInfo.usage       = usage;
 	bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-	if (vkCreateBuffer(device_, &bufferInfo, nullptr, &buffer) != VK_SUCCESS) {
+	if (vkCreateBuffer(*device_, &bufferInfo, nullptr, &buffer) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create vertex buffer!");
 	}
 
 	VkMemoryRequirements memRequirements;
-	vkGetBufferMemoryRequirements(device_, buffer, &memRequirements);
+	vkGetBufferMemoryRequirements(*device_, buffer, &memRequirements);
 
 	VkMemoryAllocateInfo allocInfo{};
 	allocInfo.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
 	allocInfo.allocationSize  = memRequirements.size;
 	allocInfo.memoryTypeIndex = findMemoryType(memRequirements.memoryTypeBits, properties);
 
-	if (vkAllocateMemory(device_, &allocInfo, nullptr, &bufferMemory) != VK_SUCCESS) {
+	if (vkAllocateMemory(*device_, &allocInfo, nullptr, &bufferMemory) != VK_SUCCESS) {
 		throw std::runtime_error("failed to allocate vertex buffer memory!");
 	}
 
-	vkBindBufferMemory(device_, buffer, bufferMemory, 0);
+	vkBindBufferMemory(*device_, buffer, bufferMemory, 0);
 }
 
 VkCommandBuffer VulkanDevice::beginSingleTimeCommands()
@@ -114,7 +115,7 @@ VkCommandBuffer VulkanDevice::beginSingleTimeCommands()
 	allocInfo.commandBufferCount = 1;
 
 	VkCommandBuffer commandBuffer;
-	vkAllocateCommandBuffers(device_, &allocInfo, &commandBuffer);
+	vkAllocateCommandBuffers(*device_, &allocInfo, &commandBuffer);
 
 	VkCommandBufferBeginInfo beginInfo{};
 	beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
@@ -133,10 +134,10 @@ void VulkanDevice::endSingleTimeCommands(VkCommandBuffer commandBuffer)
 	submitInfo.commandBufferCount = 1;
 	submitInfo.pCommandBuffers    = &commandBuffer;
 
-	vkQueueSubmit(graphicsQueue_, 1, &submitInfo, VK_NULL_HANDLE);
-	vkQueueWaitIdle(graphicsQueue_);
+	vkQueueSubmit(*graphicsQueue_, 1, &submitInfo, VK_NULL_HANDLE);
+	vkQueueWaitIdle(*graphicsQueue_);
 
-	vkFreeCommandBuffers(device_, commandPool, 1, &commandBuffer);
+	vkFreeCommandBuffers(*device_, commandPool, 1, &commandBuffer);
 }
 
 void VulkanDevice::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size)
@@ -186,23 +187,23 @@ void VulkanDevice::createImageWithInfo(
     VkImage                 &image,
     VkDeviceMemory          &imageMemory)
 {
-	if (vkCreateImage(device_, &imageInfo, nullptr, &image) != VK_SUCCESS) {
+	if (vkCreateImage(*device_, &imageInfo, nullptr, &image) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create image!");
 	}
 
 	VkMemoryRequirements memRequirements;
-	vkGetImageMemoryRequirements(device_, image, &memRequirements);
+	vkGetImageMemoryRequirements(*device_, image, &memRequirements);
 
 	VkMemoryAllocateInfo allocInfo{};
 	allocInfo.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
 	allocInfo.allocationSize  = memRequirements.size;
 	allocInfo.memoryTypeIndex = findMemoryType(memRequirements.memoryTypeBits, properties);
 
-	if (vkAllocateMemory(device_, &allocInfo, nullptr, &imageMemory) != VK_SUCCESS) {
+	if (vkAllocateMemory(*device_, &allocInfo, nullptr, &imageMemory) != VK_SUCCESS) {
 		throw std::runtime_error("failed to allocate image memory!");
 	}
 
-	if (vkBindImageMemory(device_, image, imageMemory, 0) != VK_SUCCESS) {
+	if (vkBindImageMemory(*device_, image, imageMemory, 0) != VK_SUCCESS) {
 		throw std::runtime_error("failed to bind image memory!");
 	}
 }
@@ -290,54 +291,50 @@ void VulkanDevice::pickPhysicalDevice()
 	// A more robust approach would evaluate deviceType (Discrete > Integrated),
 	// VRAM capacity, and limits.maxImageDimension2D to assign a quality score.
 
-	physicalDevice = *it;
+	physicalDevice     = *it;
+	queueFamilyIndices = findQueueFamilies(physicalDevice);
 }
 
 void VulkanDevice::createLogicalDevice()
 {
-	QueueFamilyIndices indices = findQueueFamilies(*physicalDevice);
-
-	std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
-	std::set<uint32_t>                   uniqueQueueFamilies = {indices.graphicsFamily, indices.presentFamily};
+	// Create queue create infos for each unique queue family
+	std::vector<vk::DeviceQueueCreateInfo> queueCreateInfos;
+	std::set<uint32_t>                     uniqueQueueFamilies = {
+        queueFamilyIndices.graphicsFamily.value(),
+        queueFamilyIndices.presentFamily.value()};
 
 	float queuePriority = 1.0f;
 	for (uint32_t queueFamily : uniqueQueueFamilies) {
-		VkDeviceQueueCreateInfo queueCreateInfo = {};
-		queueCreateInfo.sType                   = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-		queueCreateInfo.queueFamilyIndex        = queueFamily;
-		queueCreateInfo.queueCount              = 1;
-		queueCreateInfo.pQueuePriorities        = &queuePriority;
+		vk::DeviceQueueCreateInfo queueCreateInfo = {
+		    .queueFamilyIndex = queueFamily,
+		    .queueCount       = 1,
+		    .pQueuePriorities = &queuePriority};
 		queueCreateInfos.push_back(queueCreateInfo);
 	}
 
-	VkPhysicalDeviceFeatures deviceFeatures = {};
-	deviceFeatures.samplerAnisotropy        = VK_TRUE;
+	// Enable required features using StructureChain
+	vk::StructureChain<
+	    vk::PhysicalDeviceFeatures2,
+	    vk::PhysicalDeviceVulkan13Features,
+	    vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>
+	    featureChain = {
+	        {},                                   // vk::PhysicalDeviceFeatures2 (empty for now)
+	        {.dynamicRendering = true},           // Enable dynamic rendering from Vulkan 1.3
+	        {.extendedDynamicState = true}        // Enable extended dynamic state from the extension
+	    };
 
-	VkDeviceCreateInfo createInfo = {};
-	createInfo.sType              = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+	vk::DeviceCreateInfo deviceCreateInfo = {
+	    .pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
+	    .queueCreateInfoCount    = static_cast<uint32_t>(queueCreateInfos.size()),
+	    .pQueueCreateInfos       = queueCreateInfos.data(),
+	    .enabledExtensionCount   = static_cast<uint32_t>(deviceExtensions.size()),
+	    .ppEnabledExtensionNames = deviceExtensions.data(),
+	};
 
-	createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
-	createInfo.pQueueCreateInfos    = queueCreateInfos.data();
+	device_ = vk::raii::Device(physicalDevice, deviceCreateInfo);
 
-	createInfo.pEnabledFeatures        = &deviceFeatures;
-	createInfo.enabledExtensionCount   = static_cast<uint32_t>(deviceExtensions.size());
-	createInfo.ppEnabledExtensionNames = deviceExtensions.data();
-
-	// might not really be necessary anymore because device specific validation layers
-	// have been deprecated
-	if (enableValidationLayers) {
-		createInfo.enabledLayerCount   = static_cast<uint32_t>(validationLayers.size());
-		createInfo.ppEnabledLayerNames = validationLayers.data();
-	} else {
-		createInfo.enabledLayerCount = 0;
-	}
-
-	if (vkCreateDevice(*physicalDevice, &createInfo, nullptr, &device_) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create logical device!");
-	}
-
-	vkGetDeviceQueue(device_, indices.graphicsFamily, 0, &graphicsQueue_);
-	vkGetDeviceQueue(device_, indices.presentFamily, 0, &presentQueue_);
+	graphicsQueue_ = vk::raii::Queue(device_, queueFamilyIndices.graphicsFamily.value(), 0);
+	presentQueue_  = vk::raii::Queue(device_, queueFamilyIndices.presentFamily.value(), 0);
 }
 
 void VulkanDevice::createCommandPool()
@@ -346,11 +343,11 @@ void VulkanDevice::createCommandPool()
 
 	VkCommandPoolCreateInfo poolInfo = {};
 	poolInfo.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-	poolInfo.queueFamilyIndex        = queueFamilyIndices.graphicsFamily;
+	poolInfo.queueFamilyIndex        = queueFamilyIndices.graphicsFamily.value();
 	poolInfo.flags =
 	    VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
-	if (vkCreateCommandPool(device_, &poolInfo, nullptr, &commandPool) != VK_SUCCESS) {
+	if (vkCreateCommandPool(*device_, &poolInfo, nullptr, &commandPool) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create command pool!");
 	}
 }
@@ -514,7 +511,29 @@ bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalD
 	    vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>();
 
 	return features.template get<vk::PhysicalDeviceVulkan13Features>().dynamicRendering &&
+
 	       features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
+}
+
+QueueFamilyIndices VulkanDevice::findQueueFamilies(vk::raii::PhysicalDevice const &physicalDevice)
+{
+	QueueFamilyIndices indices;
+
+	// Get all queue families
+	std::vector<vk::QueueFamilyProperties> queueFamilies = physicalDevice.getQueueFamilyProperties();
+
+	// Find queue families that support graphics and present.
+	for (uint32_t i = 0; i < queueFamilies.size(); i++) {
+		if (queueFamilies[i].queueFlags & vk::QueueFlagBits::eGraphics) {
+			indices.graphicsFamily = i;
+		}
+
+		if (physicalDevice.getSurfaceSupportKHR(i, surface_)) {
+			indices.presentFamily = i;
+		}
+	}
+
+	return indices;
 }
 
 SwapChainSupportDetails VulkanDevice::querySwapChainSupport(VkPhysicalDevice device)
@@ -542,38 +561,6 @@ SwapChainSupportDetails VulkanDevice::querySwapChainSupport(VkPhysicalDevice dev
 		    details.presentModes.data());
 	}
 	return details;
-}
-
-QueueFamilyIndices VulkanDevice::findQueueFamilies(VkPhysicalDevice device)
-{
-	QueueFamilyIndices indices;
-
-	uint32_t queueFamilyCount = 0;
-	vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
-
-	std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
-	vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
-
-	int i = 0;
-	for (const auto &queueFamily : queueFamilies) {
-		if (queueFamily.queueCount > 0 && queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-			indices.graphicsFamily         = i;
-			indices.graphicsFamilyHasValue = true;
-		}
-		VkBool32 presentSupport = false;
-		vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface_, &presentSupport);
-		if (queueFamily.queueCount > 0 && presentSupport) {
-			indices.presentFamily         = i;
-			indices.presentFamilyHasValue = true;
-		}
-		if (indices.isComplete()) {
-			break;
-		}
-
-		i++;
-	}
-
-	return indices;
 }
 
 }        // namespace mvr

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -276,9 +276,9 @@ void VulkanDevice::createLogicalDevice()
 	    vk::PhysicalDeviceVulkan13Features,
 	    vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>
 	    featureChain = {
-	        {},                                   // vk::PhysicalDeviceFeatures2 (empty for now)
-	        {.dynamicRendering = true},           // Enable dynamic rendering from Vulkan 1.3
-	        {.extendedDynamicState = true}        // Enable extended dynamic state from the extension
+	        {},                                          // vk::PhysicalDeviceFeatures2 (empty for now)
+	        {.synchronization2 = true, .dynamicRendering = true}, // Enable sync2 and dynamic rendering
+	        {.extendedDynamicState = true}               // Enable extended dynamic state from the extension
 	    };
 
 	vk::DeviceCreateInfo deviceCreateInfo = {

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -278,10 +278,10 @@ void VulkanDevice::pickPhysicalDevice()
 
 	// Log all available physical devices
 	std::cout << "Device count: " << physicalDevices.size() << std::endl;
+	std::cout << "Available GPUs: " << std::endl;
 	for (const auto &device : physicalDevices) {
 		auto props = device.getProperties();
-		std::cout << "Available GPUs: " << props.deviceName
-		          << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
+		std::cout << props.deviceName << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
 	}
 
 	// Find the first suitable device

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -84,39 +84,28 @@ void VulkanDevice::createInstance()
 	    .engineVersion      = VK_MAKE_VERSION(1, 0, 0),
 	    .apiVersion         = vk::ApiVersion14};
 
+	VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo;
 	if (enableValidationLayers) {
-		checkValidationLayerSupport();
+		populateDebugMessengerCreateInfo(debugCreateInfo);
 	}
 
-	// flags
 	vk::InstanceCreateFlags flags = {};
 #if __APPLE__
 	flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKhr;
 #endif
-	// extensions
+
+	auto layers     = getRequiredLayers();
 	auto extensions = getRequiredExtensions();
 
-	// Verify and log required Vulkan instance extensions
-	hasGlfwRequiredInstanceExtensions();
-
 	vk::InstanceCreateInfo createInfo = {
+	    .pNext                   = enableValidationLayers ? &debugCreateInfo : nullptr,
 	    .flags                   = flags,
 	    .pApplicationInfo        = &appInfo,
+	    .enabledLayerCount       = static_cast<uint32_t>(layers.size()),
+	    .ppEnabledLayerNames     = layers.empty() ? nullptr : layers.data(),
 	    .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-	    .ppEnabledExtensionNames = extensions.data(),
+	    .ppEnabledExtensionNames = extensions.empty() ? nullptr : extensions.data(),
 	};
-
-	VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo;
-	if (enableValidationLayers) {
-		createInfo.enabledLayerCount   = static_cast<uint32_t>(validationLayers.size());
-		createInfo.ppEnabledLayerNames = validationLayers.data();
-
-		populateDebugMessengerCreateInfo(debugCreateInfo);
-		createInfo.pNext = (VkDebugUtilsMessengerCreateInfoEXT *) &debugCreateInfo;
-	} else {
-		createInfo.enabledLayerCount = 0;
-		createInfo.pNext             = nullptr;
-	}
 
 	instance = vk::raii::Instance(context, createInfo);
 }
@@ -258,13 +247,15 @@ void VulkanDevice::setupDebugMessenger()
 	}
 }
 
-void VulkanDevice::checkValidationLayerSupport()
+std::vector<const char *> VulkanDevice::getRequiredLayers()
 {
+	if (!enableValidationLayers) {
+		return {};
+	}
+
 	// Get the required layers
 	std::vector<char const *> requiredLayers;
-	if (enableValidationLayers) {
-		requiredLayers.assign(validationLayers.begin(), validationLayers.end());
-	}
+	requiredLayers.assign(validationLayers.begin(), validationLayers.end());
 
 	// Check if the required layers are supported by the Vulkan implementation.
 	auto layerProperties    = context.enumerateInstanceLayerProperties();
@@ -277,51 +268,51 @@ void VulkanDevice::checkValidationLayerSupport()
 	                                               });
 
 	if (unsupportedLayerIt != requiredLayers.end()) {
-		std::cerr << "Unsupported validation layer: " << *unsupportedLayerIt << std::endl;
+		throw std::runtime_error("Required validation layer not supported: " + std::string(*unsupportedLayerIt));
 	}
+
+	return requiredLayers;
 }
 
 std::vector<const char *> VulkanDevice::getRequiredExtensions()
 {
+	// Get the required extensions
 	uint32_t glfwExtensionCount = 0;
 	auto     glfwExtensions     = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-	std::vector<const char *> extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
-
+	std::vector<const char *> requiredExtensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
 	if (enableValidationLayers) {
-		extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+		requiredExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 	}
-
 #if __APPLE__
-	extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+	requiredExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 #endif
 
-	return extensions;
-}
-
-void VulkanDevice::hasGlfwRequiredInstanceExtensions()
-{
-	auto extensions = context.enumerateInstanceExtensionProperties();
-	std::cout << "available extensions:" << std::endl;
-	for (const auto &extension : extensions) {
-		std::cout << "\t" << extension.extensionName << std::endl;
+	// Log all available instance extensions supported by the system
+	auto supportedExtensions = context.enumerateInstanceExtensionProperties();
+	std::cout << "Supported extensions:" << std::endl;
+	for (const auto &prop : supportedExtensions) {
+		std::cout << "\t" << prop.extensionName << std::endl;
 	}
 
-	auto requiredExtensions = getRequiredExtensions();
-	std::cout << "required extensions:" << std::endl;
-	for (const auto &required : requiredExtensions) {
-		std::cout << "\t" << required << std::endl;
+	// Log the extensions requested for this instance
+	std::cout << "Required extensions:" << std::endl;
+	for (const auto &req : requiredExtensions) {
+		std::cout << "\t" << req << std::endl;
 	}
 
-	// Check if the required GLFW extensions are supported by the Vulkan implementation.
-	for (const auto &required : requiredExtensions) {
-		if (std::ranges::none_of(extensions,
-		                         [required](auto const &extension) {
-			                         return strcmp(extension.extensionName, required) == 0;
-		                         })) {
-			throw std::runtime_error("Required GLFW extension not supported: " + std::string(required));
-		}
+	// Check if the required extensions are supported by the Vulkan implementation.
+	auto it = std::ranges::find_if(requiredExtensions, [&](auto const &req) {
+		return std::ranges::none_of(supportedExtensions, [&](auto const &prop) {
+			return strcmp(prop.extensionName, req) == 0;
+		});
+	});
+
+	if (it != requiredExtensions.end()) {
+		throw std::runtime_error("Required extension not supported: " + std::string(*it));
 	}
+
+	return requiredExtensions;
 }
 
 bool VulkanDevice::checkDeviceExtensionSupport(VkPhysicalDevice device)

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <iostream>
 #include <set>
+#include <stdexcept>
 #include <string_view>
 #include <vector>
 #include <vulkan/vulkan.hpp>
@@ -20,12 +21,17 @@ namespace mvr
 VulkanDevice::VulkanDevice(Window &window) :
     window{window}
 {
-	createInstance();
-	setupDebugMessenger();
-	createSurface();
-	pickPhysicalDevice();
-	createLogicalDevice();
-	createCommandPool();
+	try {
+		createInstance();
+		setupDebugMessenger();
+		createSurface();
+		pickPhysicalDevice();
+		createLogicalDevice();
+		createCommandPool();
+	} catch (const std::runtime_error &e) {
+		std::cerr << "VulkanDevice initialization aborted: " << e.what() << std::endl;
+		throw;
+	}
 }
 
 VulkanDevice::~VulkanDevice()
@@ -267,7 +273,7 @@ void VulkanDevice::pickPhysicalDevice()
 {
 	auto physicalDevices = instance.enumeratePhysicalDevices();
 	if (physicalDevices.empty()) {
-		throw std::runtime_error("failed to find GPUs with Vulkan support!");
+		throw std::runtime_error("Failed to find GPUs with Vulkan support!");
 	}
 
 	// Log all available physical devices
@@ -283,16 +289,16 @@ void VulkanDevice::pickPhysicalDevice()
 		return isDeviceSuitable(physicalDevice);
 	});
 	if (it == physicalDevices.end()) {
-		throw std::runtime_error("failed to find a suitable GPU!");
+		throw std::runtime_error("Failed to find a suitable GPU!");
+	} else {
+		physicalDevice     = *it;
+		queueFamilyIndices = findQueueFamilies(physicalDevice);
 	}
 
 	// TODO: Implement a scoring system to select the most suitable GPU.
 	// Currently, it picks the first one that meets the minimum requirements.
 	// A more robust approach would evaluate deviceType (Discrete > Integrated),
 	// VRAM capacity, and limits.maxImageDimension2D to assign a quality score.
-
-	physicalDevice     = *it;
-	queueFamilyIndices = findQueueFamilies(physicalDevice);
 }
 
 void VulkanDevice::createLogicalDevice()
@@ -459,13 +465,11 @@ std::vector<const char *> VulkanDevice::getRequiredExtensions()
 
 bool VulkanDevice::isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice)
 {
-	bool supportsVulkan1_3          = hasRequiredApiVersion(physicalDevice);
-	bool supportsGraphics           = hasGraphicsSupport(physicalDevice);
-	bool supportsRequiredExtensions = hasRequiredExtensions(physicalDevice);
-	bool supportsRequiredFeatures   = hasRequiredFeatures(physicalDevice);
-	bool supportsSwapChain          = hasSwapchainSupport(physicalDevice);
-
-	return supportsVulkan1_3 && supportsGraphics && supportsRequiredExtensions && supportsRequiredFeatures && supportsSwapChain;
+	return hasRequiredApiVersion(physicalDevice) &&
+	       hasGraphicsSupport(physicalDevice) &&
+	       hasRequiredExtensions(physicalDevice) &&
+	       hasRequiredFeatures(physicalDevice) &&
+	       hasSwapchainSupport(physicalDevice);
 }
 
 bool VulkanDevice::hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const
@@ -529,17 +533,13 @@ bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalD
 
 bool VulkanDevice::hasSwapchainSupport(vk::raii::PhysicalDevice const &physicalDevice) const
 {
-	if (hasRequiredExtensions(physicalDevice)) {
-		SwapChainSupportDetails swapChainSupport = querySwapChainSupport(physicalDevice);
-		bool                    result           = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
-		if (!result) {
-			std::cerr << " - Does not support required swapchain support" << std::endl;
-		}
-
-		return result;
+	SwapChainSupportDetails swapChainSupport = querySwapChainSupport(physicalDevice);
+	bool                    result           = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
+	if (!result) {
+		std::cerr << " - Does not support required swapchain support" << std::endl;
 	}
 
-	return false;
+	return result;
 }
 
 QueueFamilyIndices VulkanDevice::findQueueFamilies(vk::raii::PhysicalDevice const &physicalDevice) const

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -91,7 +91,7 @@ void VulkanDevice::createInstance()
 
 	vk::InstanceCreateFlags flags = {};
 #if __APPLE__
-	flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKhr;
+	flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
 #endif
 
 	auto layers     = getRequiredLayers();

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -10,19 +10,10 @@
 namespace mvr
 {
 
-// callback functions
-VKAPI_ATTR vk::Bool32 VKAPI_CALL VulkanDevice::debugCallback(
-    vk::DebugUtilsMessageSeverityFlagBitsEXT      severity,
-    vk::DebugUtilsMessageTypeFlagsEXT             type,
-    const vk::DebugUtilsMessengerCallbackDataEXT *pCallbackData,
-    void                                         *pUserData)
-{
-	std::cerr << "validation layer: type " << to_string(type) << " msg: " << pCallbackData->pMessage << std::endl;
+// ==================================================
+// Public Functions
+// ==================================================
 
-	return vk::False;
-}
-
-// class member functions
 VulkanDevice::VulkanDevice(Window &window) :
     window{window}
 {
@@ -42,354 +33,22 @@ VulkanDevice::~VulkanDevice()
 	vkDestroySurfaceKHR(*instance, surface_, nullptr);
 }
 
-void VulkanDevice::createInstance()
+// ==================================================
+// Utilities
+// ==================================================
+
+uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
 {
-	constexpr vk::ApplicationInfo appInfo{
-	    .pApplicationName   = "MyVulkanRenderer App",
-	    .applicationVersion = VK_MAKE_VERSION(1, 0, 0),
-	    .pEngineName        = "No Engine",
-	    .engineVersion      = VK_MAKE_VERSION(1, 0, 0),
-	    .apiVersion         = vk::ApiVersion14};
-
-	vk::DebugUtilsMessengerCreateInfoEXT debugCreateInfo;
-	if (enableValidationLayers) {
-		populateDebugMessengerCreateInfo(debugCreateInfo);
-	}
-
-	vk::InstanceCreateFlags flags = {};
-#if __APPLE__
-	flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
-#endif
-
-	auto layers     = getRequiredLayers();
-	auto extensions = getRequiredExtensions();
-
-	vk::InstanceCreateInfo createInfo = {
-	    .pNext                   = enableValidationLayers ? &debugCreateInfo : nullptr,
-	    .flags                   = flags,
-	    .pApplicationInfo        = &appInfo,
-	    .enabledLayerCount       = static_cast<uint32_t>(layers.size()),
-	    .ppEnabledLayerNames     = layers.empty() ? nullptr : layers.data(),
-	    .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-	    .ppEnabledExtensionNames = extensions.empty() ? nullptr : extensions.data(),
-	};
-
-	instance = vk::raii::Instance(context, createInfo);
-}
-
-void VulkanDevice::pickPhysicalDevice()
-{
-	auto physicalDevices = instance.enumeratePhysicalDevices();
-	if (physicalDevices.empty()) {
-		throw std::runtime_error("failed to find GPUs with Vulkan support!");
-	}
-
-	// Log all available physical devices
-	std::cout << "Device count: " << physicalDevices.size() << std::endl;
-	for (const auto &device : physicalDevices) {
-		auto props = device.getProperties();
-		std::cout << "Physical device: " << props.deviceName
-		          << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
-	}
-
-	// Find the first suitable device
-	auto const it = std::ranges::find_if(physicalDevices, [&](auto const &physicalDevice) {
-		return isDeviceSuitable(physicalDevice);
-	});
-	if (it == physicalDevices.end()) {
-		throw std::runtime_error("failed to find a suitable GPU!");
-	}
-
-	// TODO: Implement a scoring system to select the most suitable GPU.
-	// Currently, it picks the first one that meets the minimum requirements.
-	// A more robust approach would evaluate deviceType (Discrete > Integrated),
-	// VRAM capacity, and limits.maxImageDimension2D to assign a quality score.
-
-	physicalDevice = *it;
-}
-
-void VulkanDevice::createLogicalDevice()
-{
-	QueueFamilyIndices indices = findQueueFamilies(*physicalDevice);
-
-	std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
-	std::set<uint32_t>                   uniqueQueueFamilies = {indices.graphicsFamily, indices.presentFamily};
-
-	float queuePriority = 1.0f;
-	for (uint32_t queueFamily : uniqueQueueFamilies) {
-		VkDeviceQueueCreateInfo queueCreateInfo = {};
-		queueCreateInfo.sType                   = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-		queueCreateInfo.queueFamilyIndex        = queueFamily;
-		queueCreateInfo.queueCount              = 1;
-		queueCreateInfo.pQueuePriorities        = &queuePriority;
-		queueCreateInfos.push_back(queueCreateInfo);
-	}
-
-	VkPhysicalDeviceFeatures deviceFeatures = {};
-	deviceFeatures.samplerAnisotropy        = VK_TRUE;
-
-	VkDeviceCreateInfo createInfo = {};
-	createInfo.sType              = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-
-	createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
-	createInfo.pQueueCreateInfos    = queueCreateInfos.data();
-
-	createInfo.pEnabledFeatures        = &deviceFeatures;
-	createInfo.enabledExtensionCount   = static_cast<uint32_t>(deviceExtensions.size());
-	createInfo.ppEnabledExtensionNames = deviceExtensions.data();
-
-	// might not really be necessary anymore because device specific validation layers
-	// have been deprecated
-	if (enableValidationLayers) {
-		createInfo.enabledLayerCount   = static_cast<uint32_t>(validationLayers.size());
-		createInfo.ppEnabledLayerNames = validationLayers.data();
-	} else {
-		createInfo.enabledLayerCount = 0;
-	}
-
-	if (vkCreateDevice(*physicalDevice, &createInfo, nullptr, &device_) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create logical device!");
-	}
-
-	vkGetDeviceQueue(device_, indices.graphicsFamily, 0, &graphicsQueue_);
-	vkGetDeviceQueue(device_, indices.presentFamily, 0, &presentQueue_);
-}
-
-void VulkanDevice::createCommandPool()
-{
-	QueueFamilyIndices queueFamilyIndices = findPhysicalQueueFamilies();
-
-	VkCommandPoolCreateInfo poolInfo = {};
-	poolInfo.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-	poolInfo.queueFamilyIndex        = queueFamilyIndices.graphicsFamily;
-	poolInfo.flags =
-	    VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-
-	if (vkCreateCommandPool(device_, &poolInfo, nullptr, &commandPool) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create command pool!");
-	}
-}
-
-void VulkanDevice::createSurface()
-{
-	window.createWindowSurface(*instance, &surface_);
-}
-
-bool VulkanDevice::isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice)
-{
-	bool supportsVulkan1_3   = hasRequiredApiVersion(physicalDevice);
-	bool supportGraphics     = hasGraphicsSupport(physicalDevice);
-	bool extensionsSupported = hasRequiredExtensions(physicalDevice);
-	bool featuresSupported   = hasRequiredFeatures(physicalDevice);
-	bool swapChainAdequate   = false;
-	if (extensionsSupported) {
-		SwapChainSupportDetails swapChainSupport = querySwapChainSupport(*physicalDevice);
-		swapChainAdequate                        = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
-	}
-
-	return supportsVulkan1_3 && supportGraphics && extensionsSupported && featuresSupported && swapChainAdequate;
-}
-
-bool VulkanDevice::hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const
-{
-	// Check if the physicalDevice supports the Vulkan 1.3 API version
-	return physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
-}
-
-bool VulkanDevice::hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const
-{
-	// Check if any of the queue families support graphics operations
-	auto queueFamilies = physicalDevice.getQueueFamilyProperties();
-
-	return std::ranges::any_of(queueFamilies, [](auto const &qfp) {
-		return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics);
-	});
-}
-
-bool VulkanDevice::hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const
-{
-	// Check if all required physicalDevice extensions are available
-	auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
-
-	auto isSupported = [&](const char *extensionName) {
-		return std::ranges::any_of(availableDeviceExtensions, [&](auto const &prop) {
-			return std::string_view(prop.extensionName) == extensionName;
-		});
-	};
-
-	return std::ranges::all_of(deviceExtensions, isSupported);
-}
-
-bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const
-{
-	// Check if the physicalDevice supports the required features (dynamic rendering and extended dynamic state)
-	auto features = physicalDevice.template getFeatures2<
-	    vk::PhysicalDeviceFeatures2,
-	    vk::PhysicalDeviceVulkan13Features,
-	    vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-
-	return features.template get<vk::PhysicalDeviceVulkan13Features>().dynamicRendering &&
-	       features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
-}
-
-void VulkanDevice::populateDebugMessengerCreateInfo(
-    vk::DebugUtilsMessengerCreateInfoEXT &debugInfo)
-{
-	debugInfo.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning |
-	                            vk::DebugUtilsMessageSeverityFlagBitsEXT::eError;
-	debugInfo.messageType = vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral |
-	                        vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation |
-	                        vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance;
-	debugInfo.pfnUserCallback = debugCallback;
-	debugInfo.pUserData       = nullptr;        // Optional
-}
-
-void VulkanDevice::setupDebugMessenger()
-{
-	if (!enableValidationLayers) {
-		return;
-	}
-
-	vk::DebugUtilsMessengerCreateInfoEXT debugInfo;
-	populateDebugMessengerCreateInfo(debugInfo);
-	debugMessenger = instance.createDebugUtilsMessengerEXT(debugInfo);
-}
-
-std::vector<const char *> VulkanDevice::getRequiredLayers()
-{
-	if (!enableValidationLayers) {
-		return {};
-	}
-
-	// Get the required layers
-	std::vector<char const *> requiredLayers;
-	requiredLayers.assign(validationLayers.begin(), validationLayers.end());
-
-	// Log all available instance layers supported by the system
-	auto supportedLayers = context.enumerateInstanceLayerProperties();
-	std::cout << "Supported layers:" << std::endl;
-	for (const auto &prop : supportedLayers) {
-		std::cout << "\t" << prop.layerName << std::endl;
-	}
-
-	// Log the layers requested for this instance
-	std::cout << "Required layers:" << std::endl;
-	for (const auto &req : requiredLayers) {
-		std::cout << "\t" << req << std::endl;
-	}
-
-	// Check if the required layers are supported by the Vulkan implementation.
-	auto it = std::ranges::find_if(requiredLayers, [&](auto const &req) {
-		return std::ranges::none_of(supportedLayers, [&](auto const &prop) {
-			return strcmp(prop.layerName, req) == 0;
-		});
-	});
-
-	if (it != requiredLayers.end()) {
-		throw std::runtime_error("Required validation layer not supported: " + std::string(*it));
-	}
-
-	return requiredLayers;
-}
-
-std::vector<const char *> VulkanDevice::getRequiredExtensions()
-{
-	// Get the required extensions
-	uint32_t glfwExtensionCount = 0;
-	auto     glfwExtensions     = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
-
-	std::vector<const char *> requiredExtensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
-	if (enableValidationLayers) {
-		requiredExtensions.push_back(vk::EXTDebugUtilsExtensionName);
-	}
-#if __APPLE__
-	requiredExtensions.push_back(vk::KHRPortabilityEnumerationExtensionName);
-#endif
-
-	// Log all available instance extensions supported by the system
-	auto supportedExtensions = context.enumerateInstanceExtensionProperties();
-	std::cout << "Supported extensions:" << std::endl;
-	for (const auto &prop : supportedExtensions) {
-		std::cout << "\t" << prop.extensionName << std::endl;
-	}
-
-	// Log the extensions requested for this instance
-	std::cout << "Required extensions:" << std::endl;
-	for (const auto &req : requiredExtensions) {
-		std::cout << "\t" << req << std::endl;
-	}
-
-	// Check if the required extensions are supported by the Vulkan implementation.
-	auto it = std::ranges::find_if(requiredExtensions, [&](auto const &req) {
-		return std::ranges::none_of(supportedExtensions, [&](auto const &prop) {
-			return strcmp(prop.extensionName, req) == 0;
-		});
-	});
-
-	if (it != requiredExtensions.end()) {
-		throw std::runtime_error("Required extension not supported: " + std::string(*it));
-	}
-
-	return requiredExtensions;
-}
-
-QueueFamilyIndices VulkanDevice::findQueueFamilies(VkPhysicalDevice device)
-{
-	QueueFamilyIndices indices;
-
-	uint32_t queueFamilyCount = 0;
-	vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
-
-	std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
-	vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
-
-	int i = 0;
-	for (const auto &queueFamily : queueFamilies) {
-		if (queueFamily.queueCount > 0 && queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-			indices.graphicsFamily         = i;
-			indices.graphicsFamilyHasValue = true;
+	VkPhysicalDeviceMemoryProperties memProperties;
+	vkGetPhysicalDeviceMemoryProperties(*physicalDevice, &memProperties);
+	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
+		if ((typeFilter & (1 << i)) &&
+		    (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
+			return i;
 		}
-		VkBool32 presentSupport = false;
-		vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface_, &presentSupport);
-		if (queueFamily.queueCount > 0 && presentSupport) {
-			indices.presentFamily         = i;
-			indices.presentFamilyHasValue = true;
-		}
-		if (indices.isComplete()) {
-			break;
-		}
-
-		i++;
 	}
 
-	return indices;
-}
-
-SwapChainSupportDetails VulkanDevice::querySwapChainSupport(VkPhysicalDevice device)
-{
-	SwapChainSupportDetails details;
-	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device, surface_, &details.capabilities);
-
-	uint32_t formatCount;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(device, surface_, &formatCount, nullptr);
-
-	if (formatCount != 0) {
-		details.formats.resize(formatCount);
-		vkGetPhysicalDeviceSurfaceFormatsKHR(device, surface_, &formatCount, details.formats.data());
-	}
-
-	uint32_t presentModeCount;
-	vkGetPhysicalDeviceSurfacePresentModesKHR(device, surface_, &presentModeCount, nullptr);
-
-	if (presentModeCount != 0) {
-		details.presentModes.resize(presentModeCount);
-		vkGetPhysicalDeviceSurfacePresentModesKHR(
-		    device,
-		    surface_,
-		    &presentModeCount,
-		    details.presentModes.data());
-	}
-	return details;
+	throw std::runtime_error("failed to find suitable memory type!");
 }
 
 VkFormat VulkanDevice::findSupportedFormat(
@@ -409,19 +68,9 @@ VkFormat VulkanDevice::findSupportedFormat(
 	throw std::runtime_error("failed to find supported format!");
 }
 
-uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
-{
-	VkPhysicalDeviceMemoryProperties memProperties;
-	vkGetPhysicalDeviceMemoryProperties(*physicalDevice, &memProperties);
-	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
-		if ((typeFilter & (1 << i)) &&
-		    (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
-			return i;
-		}
-	}
-
-	throw std::runtime_error("failed to find suitable memory type!");
-}
+// ==================================================
+// Buffer Helper Functions
+// ==================================================
 
 void VulkanDevice::createBuffer(
     VkDeviceSize          size,
@@ -555,6 +204,375 @@ void VulkanDevice::createImageWithInfo(
 	if (vkBindImageMemory(device_, image, imageMemory, 0) != VK_SUCCESS) {
 		throw std::runtime_error("failed to bind image memory!");
 	}
+}
+
+// ==================================================
+// Private Setup Functions
+// ==================================================
+
+void VulkanDevice::createInstance()
+{
+	constexpr vk::ApplicationInfo appInfo{
+	    .pApplicationName   = "MyVulkanRenderer App",
+	    .applicationVersion = VK_MAKE_VERSION(1, 0, 0),
+	    .pEngineName        = "No Engine",
+	    .engineVersion      = VK_MAKE_VERSION(1, 0, 0),
+	    .apiVersion         = vk::ApiVersion14};
+
+	vk::DebugUtilsMessengerCreateInfoEXT debugCreateInfo;
+	if (enableValidationLayers) {
+		populateDebugMessengerCreateInfo(debugCreateInfo);
+	}
+
+	vk::InstanceCreateFlags flags = {};
+#if __APPLE__
+	flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+#endif
+
+	auto layers     = getRequiredLayers();
+	auto extensions = getRequiredExtensions();
+
+	vk::InstanceCreateInfo createInfo = {
+	    .pNext                   = enableValidationLayers ? &debugCreateInfo : nullptr,
+	    .flags                   = flags,
+	    .pApplicationInfo        = &appInfo,
+	    .enabledLayerCount       = static_cast<uint32_t>(layers.size()),
+	    .ppEnabledLayerNames     = layers.empty() ? nullptr : layers.data(),
+	    .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
+	    .ppEnabledExtensionNames = extensions.empty() ? nullptr : extensions.data(),
+	};
+
+	instance = vk::raii::Instance(context, createInfo);
+}
+
+void VulkanDevice::setupDebugMessenger()
+{
+	if (!enableValidationLayers) {
+		return;
+	}
+
+	vk::DebugUtilsMessengerCreateInfoEXT debugInfo;
+	populateDebugMessengerCreateInfo(debugInfo);
+	debugMessenger = instance.createDebugUtilsMessengerEXT(debugInfo);
+}
+
+void VulkanDevice::createSurface()
+{
+	window.createWindowSurface(*instance, &surface_);
+}
+
+void VulkanDevice::pickPhysicalDevice()
+{
+	auto physicalDevices = instance.enumeratePhysicalDevices();
+	if (physicalDevices.empty()) {
+		throw std::runtime_error("failed to find GPUs with Vulkan support!");
+	}
+
+	// Log all available physical devices
+	std::cout << "Device count: " << physicalDevices.size() << std::endl;
+	for (const auto &device : physicalDevices) {
+		auto props = device.getProperties();
+		std::cout << "Physical device: " << props.deviceName
+		          << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
+	}
+
+	// Find the first suitable device
+	auto const it = std::ranges::find_if(physicalDevices, [&](auto const &physicalDevice) {
+		return isDeviceSuitable(physicalDevice);
+	});
+	if (it == physicalDevices.end()) {
+		throw std::runtime_error("failed to find a suitable GPU!");
+	}
+
+	// TODO: Implement a scoring system to select the most suitable GPU.
+	// Currently, it picks the first one that meets the minimum requirements.
+	// A more robust approach would evaluate deviceType (Discrete > Integrated),
+	// VRAM capacity, and limits.maxImageDimension2D to assign a quality score.
+
+	physicalDevice = *it;
+}
+
+void VulkanDevice::createLogicalDevice()
+{
+	QueueFamilyIndices indices = findQueueFamilies(*physicalDevice);
+
+	std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
+	std::set<uint32_t>                   uniqueQueueFamilies = {indices.graphicsFamily, indices.presentFamily};
+
+	float queuePriority = 1.0f;
+	for (uint32_t queueFamily : uniqueQueueFamilies) {
+		VkDeviceQueueCreateInfo queueCreateInfo = {};
+		queueCreateInfo.sType                   = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+		queueCreateInfo.queueFamilyIndex        = queueFamily;
+		queueCreateInfo.queueCount              = 1;
+		queueCreateInfo.pQueuePriorities        = &queuePriority;
+		queueCreateInfos.push_back(queueCreateInfo);
+	}
+
+	VkPhysicalDeviceFeatures deviceFeatures = {};
+	deviceFeatures.samplerAnisotropy        = VK_TRUE;
+
+	VkDeviceCreateInfo createInfo = {};
+	createInfo.sType              = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+
+	createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
+	createInfo.pQueueCreateInfos    = queueCreateInfos.data();
+
+	createInfo.pEnabledFeatures        = &deviceFeatures;
+	createInfo.enabledExtensionCount   = static_cast<uint32_t>(deviceExtensions.size());
+	createInfo.ppEnabledExtensionNames = deviceExtensions.data();
+
+	// might not really be necessary anymore because device specific validation layers
+	// have been deprecated
+	if (enableValidationLayers) {
+		createInfo.enabledLayerCount   = static_cast<uint32_t>(validationLayers.size());
+		createInfo.ppEnabledLayerNames = validationLayers.data();
+	} else {
+		createInfo.enabledLayerCount = 0;
+	}
+
+	if (vkCreateDevice(*physicalDevice, &createInfo, nullptr, &device_) != VK_SUCCESS) {
+		throw std::runtime_error("failed to create logical device!");
+	}
+
+	vkGetDeviceQueue(device_, indices.graphicsFamily, 0, &graphicsQueue_);
+	vkGetDeviceQueue(device_, indices.presentFamily, 0, &presentQueue_);
+}
+
+void VulkanDevice::createCommandPool()
+{
+	QueueFamilyIndices queueFamilyIndices = findPhysicalQueueFamilies();
+
+	VkCommandPoolCreateInfo poolInfo = {};
+	poolInfo.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+	poolInfo.queueFamilyIndex        = queueFamilyIndices.graphicsFamily;
+	poolInfo.flags =
+	    VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+
+	if (vkCreateCommandPool(device_, &poolInfo, nullptr, &commandPool) != VK_SUCCESS) {
+		throw std::runtime_error("failed to create command pool!");
+	}
+}
+
+// ==================================================
+// Private Helper Functions
+// ==================================================
+
+void VulkanDevice::populateDebugMessengerCreateInfo(
+    vk::DebugUtilsMessengerCreateInfoEXT &debugInfo)
+{
+	debugInfo.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning |
+	                            vk::DebugUtilsMessageSeverityFlagBitsEXT::eError;
+	debugInfo.messageType = vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral |
+	                        vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation |
+	                        vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance;
+	debugInfo.pfnUserCallback = debugCallback;
+	debugInfo.pUserData       = nullptr;        // Optional
+}
+
+VKAPI_ATTR vk::Bool32 VKAPI_CALL VulkanDevice::debugCallback(
+    vk::DebugUtilsMessageSeverityFlagBitsEXT      severity,
+    vk::DebugUtilsMessageTypeFlagsEXT             type,
+    const vk::DebugUtilsMessengerCallbackDataEXT *pCallbackData,
+    void                                         *pUserData)
+{
+	std::cerr << "validation layer: type " << to_string(type) << " msg: " << pCallbackData->pMessage << std::endl;
+
+	return vk::False;
+}
+
+std::vector<const char *> VulkanDevice::getRequiredLayers()
+{
+	if (!enableValidationLayers) {
+		return {};
+	}
+
+	// Get the required layers
+	std::vector<char const *> requiredLayers;
+	requiredLayers.assign(validationLayers.begin(), validationLayers.end());
+
+	// Log all available instance layers supported by the system
+	auto supportedLayers = context.enumerateInstanceLayerProperties();
+	std::cout << "Supported layers:" << std::endl;
+	for (const auto &prop : supportedLayers) {
+		std::cout << "\t" << prop.layerName << std::endl;
+	}
+
+	// Log the layers requested for this instance
+	std::cout << "Required layers:" << std::endl;
+	for (const auto &req : requiredLayers) {
+		std::cout << "\t" << req << std::endl;
+	}
+
+	// Check if the required layers are supported by the Vulkan implementation.
+	auto it = std::ranges::find_if(requiredLayers, [&](auto const &req) {
+		return std::ranges::none_of(supportedLayers, [&](auto const &prop) {
+			return strcmp(prop.layerName, req) == 0;
+		});
+	});
+
+	if (it != requiredLayers.end()) {
+		throw std::runtime_error("Required validation layer not supported: " + std::string(*it));
+	}
+
+	return requiredLayers;
+}
+
+std::vector<const char *> VulkanDevice::getRequiredExtensions()
+{
+	// Get the required extensions
+	uint32_t glfwExtensionCount = 0;
+	auto     glfwExtensions     = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
+
+	std::vector<const char *> requiredExtensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
+	if (enableValidationLayers) {
+		requiredExtensions.push_back(vk::EXTDebugUtilsExtensionName);
+	}
+#if __APPLE__
+	requiredExtensions.push_back(vk::KHRPortabilityEnumerationExtensionName);
+#endif
+
+	// Log all available instance extensions supported by the system
+	auto supportedExtensions = context.enumerateInstanceExtensionProperties();
+	std::cout << "Supported extensions:" << std::endl;
+	for (const auto &prop : supportedExtensions) {
+		std::cout << "\t" << prop.extensionName << std::endl;
+	}
+
+	// Log the extensions requested for this instance
+	std::cout << "Required extensions:" << std::endl;
+	for (const auto &req : requiredExtensions) {
+		std::cout << "\t" << req << std::endl;
+	}
+
+	// Check if the required extensions are supported by the Vulkan implementation.
+	auto it = std::ranges::find_if(requiredExtensions, [&](auto const &req) {
+		return std::ranges::none_of(supportedExtensions, [&](auto const &prop) {
+			return strcmp(prop.extensionName, req) == 0;
+		});
+	});
+
+	if (it != requiredExtensions.end()) {
+		throw std::runtime_error("Required extension not supported: " + std::string(*it));
+	}
+
+	return requiredExtensions;
+}
+
+bool VulkanDevice::isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice)
+{
+	bool supportsVulkan1_3   = hasRequiredApiVersion(physicalDevice);
+	bool supportGraphics     = hasGraphicsSupport(physicalDevice);
+	bool extensionsSupported = hasRequiredExtensions(physicalDevice);
+	bool featuresSupported   = hasRequiredFeatures(physicalDevice);
+	bool swapChainAdequate   = false;
+	if (extensionsSupported) {
+		SwapChainSupportDetails swapChainSupport = querySwapChainSupport(*physicalDevice);
+		swapChainAdequate                        = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
+	}
+
+	return supportsVulkan1_3 && supportGraphics && extensionsSupported && featuresSupported && swapChainAdequate;
+}
+
+bool VulkanDevice::hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if the physicalDevice supports the Vulkan 1.3 API version
+	return physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
+}
+
+bool VulkanDevice::hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if any of the queue families support graphics operations
+	auto queueFamilies = physicalDevice.getQueueFamilyProperties();
+
+	return std::ranges::any_of(queueFamilies, [](auto const &qfp) {
+		return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics);
+	});
+}
+
+bool VulkanDevice::hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if all required physicalDevice extensions are available
+	auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
+
+	auto isSupported = [&](const char *extensionName) {
+		return std::ranges::any_of(availableDeviceExtensions, [&](auto const &prop) {
+			return std::string_view(prop.extensionName) == extensionName;
+		});
+	};
+
+	return std::ranges::all_of(deviceExtensions, isSupported);
+}
+
+bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if the physicalDevice supports the required features (dynamic rendering and extended dynamic state)
+	auto features = physicalDevice.template getFeatures2<
+	    vk::PhysicalDeviceFeatures2,
+	    vk::PhysicalDeviceVulkan13Features,
+	    vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+
+	return features.template get<vk::PhysicalDeviceVulkan13Features>().dynamicRendering &&
+	       features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
+}
+
+SwapChainSupportDetails VulkanDevice::querySwapChainSupport(VkPhysicalDevice device)
+{
+	SwapChainSupportDetails details;
+	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device, surface_, &details.capabilities);
+
+	uint32_t formatCount;
+	vkGetPhysicalDeviceSurfaceFormatsKHR(device, surface_, &formatCount, nullptr);
+
+	if (formatCount != 0) {
+		details.formats.resize(formatCount);
+		vkGetPhysicalDeviceSurfaceFormatsKHR(device, surface_, &formatCount, details.formats.data());
+	}
+
+	uint32_t presentModeCount;
+	vkGetPhysicalDeviceSurfacePresentModesKHR(device, surface_, &presentModeCount, nullptr);
+
+	if (presentModeCount != 0) {
+		details.presentModes.resize(presentModeCount);
+		vkGetPhysicalDeviceSurfacePresentModesKHR(
+		    device,
+		    surface_,
+		    &presentModeCount,
+		    details.presentModes.data());
+	}
+	return details;
+}
+
+QueueFamilyIndices VulkanDevice::findQueueFamilies(VkPhysicalDevice device)
+{
+	QueueFamilyIndices indices;
+
+	uint32_t queueFamilyCount = 0;
+	vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+
+	std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+	vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+
+	int i = 0;
+	for (const auto &queueFamily : queueFamilies) {
+		if (queueFamily.queueCount > 0 && queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+			indices.graphicsFamily         = i;
+			indices.graphicsFamilyHasValue = true;
+		}
+		VkBool32 presentSupport = false;
+		vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface_, &presentSupport);
+		if (queueFamily.queueCount > 0 && presentSupport) {
+			indices.presentFamily         = i;
+			indices.presentFamilyHasValue = true;
+		}
+		if (indices.isComplete()) {
+			break;
+		}
+
+		i++;
+	}
+
+	return indices;
 }
 
 }        // namespace mvr

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -9,7 +9,6 @@
 #include <stdexcept>
 #include <string_view>
 #include <vector>
-#include <vulkan/vulkan.hpp>
 
 namespace mvr
 {
@@ -37,8 +36,6 @@ VulkanDevice::VulkanDevice(Window &window) :
 VulkanDevice::~VulkanDevice()
 {
 	vkDestroyCommandPool(*device_, commandPool, nullptr);
-
-	vkDestroySurfaceKHR(*instance, surface_, nullptr);
 }
 
 // ==================================================
@@ -266,7 +263,9 @@ void VulkanDevice::setupDebugMessenger()
 
 void VulkanDevice::createSurface()
 {
-	window.createWindowSurface(*instance, &surface_);
+	VkSurfaceKHR _surface;
+	window.createWindowSurface(*instance, &_surface);
+	surface_ = vk::raii::SurfaceKHR(instance, _surface);
 }
 
 void VulkanDevice::pickPhysicalDevice()
@@ -569,24 +568,24 @@ QueueFamilyIndices VulkanDevice::findQueueFamilies(vk::raii::PhysicalDevice cons
 SwapChainSupportDetails VulkanDevice::querySwapChainSupport(vk::raii::PhysicalDevice const &physicalDevice) const
 {
 	SwapChainSupportDetails details;
-	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(*physicalDevice, surface_, &details.capabilities);
+	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(*physicalDevice, *surface_, &details.capabilities);
 
 	uint32_t formatCount;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, surface_, &formatCount, nullptr);
+	vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, *surface_, &formatCount, nullptr);
 
 	if (formatCount != 0) {
 		details.formats.resize(formatCount);
-		vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, surface_, &formatCount, details.formats.data());
+		vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, *surface_, &formatCount, details.formats.data());
 	}
 
 	uint32_t presentModeCount;
-	vkGetPhysicalDeviceSurfacePresentModesKHR(*physicalDevice, surface_, &presentModeCount, nullptr);
+	vkGetPhysicalDeviceSurfacePresentModesKHR(*physicalDevice, *surface_, &presentModeCount, nullptr);
 
 	if (presentModeCount != 0) {
 		details.presentModes.resize(presentModeCount);
 		vkGetPhysicalDeviceSurfacePresentModesKHR(
 		    *physicalDevice,
-		    surface_,
+		    *surface_,
 		    &presentModeCount,
 		    details.presentModes.data());
 	}

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -281,7 +281,7 @@ void VulkanDevice::pickPhysicalDevice()
 	std::cout << "Available GPUs: " << std::endl;
 	for (const auto &device : physicalDevices) {
 		auto props = device.getProperties();
-		std::cout << props.deviceName << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
+		std::cout << "   " << props.deviceName << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
 	}
 
 	// Find the first suitable device

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -1,6 +1,6 @@
 #include "vulkan_device.h"
 
-// std headers
+// std
 #include <algorithm>
 #include <cstring>
 #include <iostream>
@@ -257,18 +257,28 @@ std::vector<const char *> VulkanDevice::getRequiredLayers()
 	std::vector<char const *> requiredLayers;
 	requiredLayers.assign(validationLayers.begin(), validationLayers.end());
 
-	// Check if the required layers are supported by the Vulkan implementation.
-	auto layerProperties    = context.enumerateInstanceLayerProperties();
-	auto unsupportedLayerIt = std::ranges::find_if(requiredLayers,
-	                                               [&layerProperties](auto const &requiredLayer) {
-		                                               return std::ranges::none_of(layerProperties,
-		                                                                           [requiredLayer](auto const &layerProperty) {
-			                                                                           return strcmp(layerProperty.layerName, requiredLayer) == 0;
-		                                                                           });
-	                                               });
+	// Log all available instance layers supported by the system
+	auto supportedLayers = context.enumerateInstanceLayerProperties();
+	std::cout << "Supported layers:" << std::endl;
+	for (const auto &prop : supportedLayers) {
+		std::cout << "\t" << prop.layerName << std::endl;
+	}
 
-	if (unsupportedLayerIt != requiredLayers.end()) {
-		throw std::runtime_error("Required validation layer not supported: " + std::string(*unsupportedLayerIt));
+	// Log the layers requested for this instance
+	std::cout << "Required layers:" << std::endl;
+	for (const auto &req : requiredLayers) {
+		std::cout << "\t" << req << std::endl;
+	}
+
+	// Check if the required layers are supported by the Vulkan implementation.
+	auto it = std::ranges::find_if(requiredLayers, [&](auto const &req) {
+		return std::ranges::none_of(supportedLayers, [&](auto const &prop) {
+			return strcmp(prop.layerName, req) == 0;
+		});
+	});
+
+	if (it != requiredLayers.end()) {
+		throw std::runtime_error("Required validation layer not supported: " + std::string(*it));
 	}
 
 	return requiredLayers;
@@ -282,10 +292,10 @@ std::vector<const char *> VulkanDevice::getRequiredExtensions()
 
 	std::vector<const char *> requiredExtensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
 	if (enableValidationLayers) {
-		requiredExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+		requiredExtensions.push_back(vk::EXTDebugUtilsExtensionName);
 	}
 #if __APPLE__
-	requiredExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+	requiredExtensions.push_back(vk::KHRPortabilityEnumerationExtensionName);
 #endif
 
 	// Log all available instance extensions supported by the system

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <iostream>
 #include <set>
+#include <vector>
 
 namespace mvr
 {
@@ -76,16 +77,16 @@ VulkanDevice::~VulkanDevice()
 
 void VulkanDevice::createInstance()
 {
-	if (enableValidationLayers && !checkValidationLayerSupport()) {
-		throw std::runtime_error("validation layers requested, but not available!");
-	}
-
 	constexpr vk::ApplicationInfo appInfo{
 	    .pApplicationName   = "MyVulkanRenderer App",
 	    .applicationVersion = VK_MAKE_VERSION(1, 0, 0),
 	    .pEngineName        = "No Engine",
 	    .engineVersion      = VK_MAKE_VERSION(1, 0, 0),
 	    .apiVersion         = vk::ApiVersion14};
+
+	if (enableValidationLayers) {
+		checkValidationLayerSupport();
+	}
 
 	// flags
 	vk::InstanceCreateFlags flags = {};
@@ -257,30 +258,27 @@ void VulkanDevice::setupDebugMessenger()
 	}
 }
 
-bool VulkanDevice::checkValidationLayerSupport()
+void VulkanDevice::checkValidationLayerSupport()
 {
-	uint32_t layerCount;
-	vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
-
-	std::vector<VkLayerProperties> availableLayers(layerCount);
-	vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
-
-	for (const char *layerName : validationLayers) {
-		bool layerFound = false;
-
-		for (const auto &layerProperties : availableLayers) {
-			if (strcmp(layerName, layerProperties.layerName) == 0) {
-				layerFound = true;
-				break;
-			}
-		}
-
-		if (!layerFound) {
-			return false;
-		}
+	// Get the required layers
+	std::vector<char const *> requiredLayers;
+	if (enableValidationLayers) {
+		requiredLayers.assign(validationLayers.begin(), validationLayers.end());
 	}
 
-	return true;
+	// Check if the required layers are supported by the Vulkan implementation.
+	auto layerProperties    = context.enumerateInstanceLayerProperties();
+	auto unsupportedLayerIt = std::ranges::find_if(requiredLayers,
+	                                               [&layerProperties](auto const &requiredLayer) {
+		                                               return std::ranges::none_of(layerProperties,
+		                                                                           [requiredLayer](auto const &layerProperty) {
+			                                                                           return strcmp(layerProperty.layerName, requiredLayer) == 0;
+		                                                                           });
+	                                               });
+
+	if (unsupportedLayerIt != requiredLayers.end()) {
+		std::cerr << "Unsupported validation layer: " << *unsupportedLayerIt << std::endl;
+	}
 }
 
 std::vector<const char *> VulkanDevice::getRequiredExtensions()

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -459,33 +459,36 @@ std::vector<const char *> VulkanDevice::getRequiredExtensions()
 
 bool VulkanDevice::isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice)
 {
-	bool supportsVulkan1_3   = hasRequiredApiVersion(physicalDevice);
-	bool supportGraphics     = hasGraphicsSupport(physicalDevice);
-	bool extensionsSupported = hasRequiredExtensions(physicalDevice);
-	bool featuresSupported   = hasRequiredFeatures(physicalDevice);
-	bool swapChainAdequate   = false;
-	if (extensionsSupported) {
-		SwapChainSupportDetails swapChainSupport = querySwapChainSupport(*physicalDevice);
-		swapChainAdequate                        = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
-	}
+	bool supportsVulkan1_3          = hasRequiredApiVersion(physicalDevice);
+	bool supportsGraphics           = hasGraphicsSupport(physicalDevice);
+	bool supportsRequiredExtensions = hasRequiredExtensions(physicalDevice);
+	bool supportsRequiredFeatures   = hasRequiredFeatures(physicalDevice);
+	bool supportsSwapChain          = hasSwapchainSupport(physicalDevice);
 
-	return supportsVulkan1_3 && supportGraphics && extensionsSupported && featuresSupported && swapChainAdequate;
+	return supportsVulkan1_3 && supportsGraphics && supportsRequiredExtensions && supportsRequiredFeatures && supportsSwapChain;
 }
 
 bool VulkanDevice::hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const
 {
 	// Check if the physicalDevice supports the Vulkan 1.3 API version
-	return physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
+	bool result = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
+	if (!result) {
+		std::cerr << " - Does not support Vulkan 1.3 API version" << std::endl;
+	}
+
+	return result;
 }
 
 bool VulkanDevice::hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const
 {
 	// Check if any of the queue families support graphics operations
-	auto queueFamilies = physicalDevice.getQueueFamilyProperties();
+	QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
+	bool               result  = indices.isComplete();
+	if (!result) {
+		std::cerr << " - Missing required queue families" << std::endl;
+	}
 
-	return std::ranges::any_of(queueFamilies, [](auto const &qfp) {
-		return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics);
-	});
+	return result;
 }
 
 bool VulkanDevice::hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const
@@ -499,7 +502,12 @@ bool VulkanDevice::hasRequiredExtensions(vk::raii::PhysicalDevice const &physica
 		});
 	};
 
-	return std::ranges::all_of(deviceExtensions, isSupported);
+	bool result = std::ranges::all_of(deviceExtensions, isSupported);
+	if (!result) {
+		std::cerr << " - Missing required extensions" << std::endl;
+	}
+
+	return result;
 }
 
 bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const
@@ -510,12 +518,31 @@ bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalD
 	    vk::PhysicalDeviceVulkan13Features,
 	    vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>();
 
-	return features.template get<vk::PhysicalDeviceVulkan13Features>().dynamicRendering &&
+	bool result = features.template get<vk::PhysicalDeviceVulkan13Features>().dynamicRendering &&
+	              features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
+	if (!result) {
+		std::cerr << " - Does not support required features" << std::endl;
+	}
 
-	       features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
+	return result;
 }
 
-QueueFamilyIndices VulkanDevice::findQueueFamilies(vk::raii::PhysicalDevice const &physicalDevice)
+bool VulkanDevice::hasSwapchainSupport(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	if (hasRequiredExtensions(physicalDevice)) {
+		SwapChainSupportDetails swapChainSupport = querySwapChainSupport(physicalDevice);
+		bool                    result           = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
+		if (!result) {
+			std::cerr << " - Does not support required swapchain support" << std::endl;
+		}
+
+		return result;
+	}
+
+	return false;
+}
+
+QueueFamilyIndices VulkanDevice::findQueueFamilies(vk::raii::PhysicalDevice const &physicalDevice) const
 {
 	QueueFamilyIndices indices;
 
@@ -536,26 +563,26 @@ QueueFamilyIndices VulkanDevice::findQueueFamilies(vk::raii::PhysicalDevice cons
 	return indices;
 }
 
-SwapChainSupportDetails VulkanDevice::querySwapChainSupport(VkPhysicalDevice device)
+SwapChainSupportDetails VulkanDevice::querySwapChainSupport(vk::raii::PhysicalDevice const &physicalDevice) const
 {
 	SwapChainSupportDetails details;
-	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device, surface_, &details.capabilities);
+	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(*physicalDevice, surface_, &details.capabilities);
 
 	uint32_t formatCount;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(device, surface_, &formatCount, nullptr);
+	vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, surface_, &formatCount, nullptr);
 
 	if (formatCount != 0) {
 		details.formats.resize(formatCount);
-		vkGetPhysicalDeviceSurfaceFormatsKHR(device, surface_, &formatCount, details.formats.data());
+		vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, surface_, &formatCount, details.formats.data());
 	}
 
 	uint32_t presentModeCount;
-	vkGetPhysicalDeviceSurfacePresentModesKHR(device, surface_, &presentModeCount, nullptr);
+	vkGetPhysicalDeviceSurfacePresentModesKHR(*physicalDevice, surface_, &presentModeCount, nullptr);
 
 	if (presentModeCount != 0) {
 		details.presentModes.resize(presentModeCount);
 		vkGetPhysicalDeviceSurfacePresentModesKHR(
-		    device,
+		    *physicalDevice,
 		    surface_,
 		    &presentModeCount,
 		    details.presentModes.data());

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -45,7 +45,7 @@ VulkanDevice::~VulkanDevice()
 uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
 {
 	VkPhysicalDeviceMemoryProperties memProperties;
-	vkGetPhysicalDeviceMemoryProperties(*physicalDevice, &memProperties);
+	vkGetPhysicalDeviceMemoryProperties(*physicalDevice_, &memProperties);
 	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
 		if ((typeFilter & (1 << i)) &&
 		    (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
@@ -61,7 +61,7 @@ VkFormat VulkanDevice::findSupportedFormat(
 {
 	for (VkFormat format : candidates) {
 		VkFormatProperties props;
-		vkGetPhysicalDeviceFormatProperties(*physicalDevice, format, &props);
+		vkGetPhysicalDeviceFormatProperties(*physicalDevice_, format, &props);
 
 		if (tiling == VK_IMAGE_TILING_LINEAR && (props.linearTilingFeatures & features) == features) {
 			return format;
@@ -290,10 +290,10 @@ void VulkanDevice::pickPhysicalDevice()
 	if (it == physicalDevices.end()) {
 		throw std::runtime_error("Failed to find a suitable GPU!");
 	} else {
-		physicalDevice     = *it;
-		queueFamilyIndices = findQueueFamilies(physicalDevice);
+		physicalDevice_    = *it;
+		queueFamilyIndices = findQueueFamilies(physicalDevice_);
 
-		vk::PhysicalDeviceProperties deviceProperties = physicalDevice.getProperties();
+		vk::PhysicalDeviceProperties deviceProperties = physicalDevice_.getProperties();
 		std::cout << "Selected GPU: " << deviceProperties.deviceName << std::endl;
 	}
 
@@ -339,7 +339,7 @@ void VulkanDevice::createLogicalDevice()
 	    .ppEnabledExtensionNames = deviceExtensions.data(),
 	};
 
-	device_ = vk::raii::Device(physicalDevice, deviceCreateInfo);
+	device_ = vk::raii::Device(physicalDevice_, deviceCreateInfo);
 
 	graphicsQueue_ = vk::raii::Queue(device_, queueFamilyIndices.graphicsFamily.value(), 0);
 	presentQueue_  = vk::raii::Queue(device_, queueFamilyIndices.presentFamily.value(), 0);

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -1,5 +1,4 @@
 #include "vulkan_device.h"
-#include "vulkan/vulkan.hpp"
 
 // std
 #include <algorithm>
@@ -13,9 +12,7 @@
 namespace mvr
 {
 
-// ==================================================
-// Public Functions
-// ==================================================
+// Constructor & Destructor
 
 VulkanDevice::VulkanDevice(Window &window) :
     window{window}
@@ -38,9 +35,7 @@ VulkanDevice::~VulkanDevice()
 	vkDestroyCommandPool(*device_, commandPool, nullptr);
 }
 
-// ==================================================
-// Utilities
-// ==================================================
+// Public Methods
 
 uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
 {
@@ -72,10 +67,6 @@ VkFormat VulkanDevice::findSupportedFormat(
 	}
 	throw std::runtime_error("failed to find supported format!");
 }
-
-// ==================================================
-// Buffer Helper Functions
-// ==================================================
 
 void VulkanDevice::createBuffer(
     VkDeviceSize          size,
@@ -211,9 +202,7 @@ void VulkanDevice::createImageWithInfo(
 	}
 }
 
-// ==================================================
-// Private Setup Functions
-// ==================================================
+// Private Init Methods
 
 void VulkanDevice::createInstance()
 {
@@ -360,9 +349,7 @@ void VulkanDevice::createCommandPool()
 	}
 }
 
-// ==================================================
-// Private Helper Functions
-// ==================================================
+// Helper Methods
 
 void VulkanDevice::populateDebugMessengerCreateInfo(
     vk::DebugUtilsMessengerCreateInfoEXT &debugInfo)

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -1,11 +1,10 @@
 #include "vulkan_device.h"
 
 // std headers
+#include <algorithm>
 #include <cstring>
 #include <iostream>
 #include <set>
-#include <unordered_set>
-#include <vulkan/vulkan.hpp>
 
 namespace mvr
 {
@@ -88,17 +87,24 @@ void VulkanDevice::createInstance()
 	    .engineVersion      = VK_MAKE_VERSION(1, 0, 0),
 	    .apiVersion         = vk::ApiVersion14};
 
-	vk::InstanceCreateInfo createInfo = {
-	    .pApplicationInfo = &appInfo,
-	};
-
+	// flags
+	vk::InstanceCreateFlags flags = {};
 #if __APPLE__
-	createInfo.flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKhr;
+	flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKhr;
 #endif
 
-	auto extensions                    = getRequiredExtensions();
-	createInfo.enabledExtensionCount   = static_cast<uint32_t>(extensions.size());
-	createInfo.ppEnabledExtensionNames = extensions.data();
+	// extensions
+	auto extensions = getRequiredExtensions();
+
+	// Check if the required GLFW extensions are supported by the Vulkan implementation.
+	hasGlfwRequiredInstanceExtensions();
+
+	vk::InstanceCreateInfo createInfo = {
+	    .flags                   = flags,
+	    .pApplicationInfo        = &appInfo,
+	    .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
+	    .ppEnabledExtensionNames = extensions.data(),
+	};
 
 	VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo;
 	if (enableValidationLayers) {
@@ -113,8 +119,6 @@ void VulkanDevice::createInstance()
 	}
 
 	instance = vk::raii::Instance(context, createInfo);
-
-	hasGflwRequiredInstanceExtensions();
 }
 
 void VulkanDevice::pickPhysicalDevice()
@@ -282,9 +286,8 @@ bool VulkanDevice::checkValidationLayerSupport()
 
 std::vector<const char *> VulkanDevice::getRequiredExtensions()
 {
-	uint32_t     glfwExtensionCount = 0;
-	const char **glfwExtensions;
-	glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
+	uint32_t glfwExtensionCount = 0;
+	auto     glfwExtensions     = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
 	std::vector<const char *> extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
 
@@ -294,32 +297,32 @@ std::vector<const char *> VulkanDevice::getRequiredExtensions()
 
 #if __APPLE__
 	extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-	extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 #endif
 
 	return extensions;
 }
 
-void VulkanDevice::hasGflwRequiredInstanceExtensions()
+void VulkanDevice::hasGlfwRequiredInstanceExtensions()
 {
-	uint32_t extensionCount = 0;
-	vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
-	std::vector<VkExtensionProperties> extensions(extensionCount);
-	vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, extensions.data());
+	auto extensions = context.enumerateInstanceExtensionProperties();
 
 	std::cout << "available extensions:" << std::endl;
-	std::unordered_set<std::string> available;
 	for (const auto &extension : extensions) {
 		std::cout << "\t" << extension.extensionName << std::endl;
-		available.insert(extension.extensionName);
 	}
 
 	std::cout << "required extensions:" << std::endl;
 	auto requiredExtensions = getRequiredExtensions();
 	for (const auto &required : requiredExtensions) {
 		std::cout << "\t" << required << std::endl;
-		if (available.find(required) == available.end()) {
-			throw std::runtime_error("Missing required glfw extension");
+	}
+
+	for (const auto &required : requiredExtensions) {
+		if (std::ranges::none_of(extensions,
+		                         [required](auto const &extension) {
+			                         return strcmp(extension.extensionName, required) == 0;
+		                         })) {
+			throw std::runtime_error("Required GLFW extension not supported: " + std::string(required));
 		}
 	}
 }

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -79,33 +79,38 @@ void VulkanDevice::createInstance()
 
 void VulkanDevice::pickPhysicalDevice()
 {
-	uint32_t deviceCount = 0;
-	vkEnumeratePhysicalDevices(*instance, &deviceCount, nullptr);
-	if (deviceCount == 0) {
+	auto physicalDevices = instance.enumeratePhysicalDevices();
+	if (physicalDevices.empty()) {
 		throw std::runtime_error("failed to find GPUs with Vulkan support!");
 	}
-	std::cout << "Device count: " << deviceCount << std::endl;
-	std::vector<VkPhysicalDevice> devices(deviceCount);
-	vkEnumeratePhysicalDevices(*instance, &deviceCount, devices.data());
 
-	for (const auto &device : devices) {
-		if (isDeviceSuitable(device)) {
-			physicalDevice = device;
-			break;
-		}
+	// Log all available physical devices
+	std::cout << "Device count: " << physicalDevices.size() << std::endl;
+	for (const auto &device : physicalDevices) {
+		auto props = device.getProperties();
+		std::cout << "Physical device: " << props.deviceName
+		          << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
 	}
 
-	if (physicalDevice == VK_NULL_HANDLE) {
+	// Find the first suitable device
+	auto const it = std::ranges::find_if(physicalDevices, [&](auto const &physicalDevice) {
+		return isDeviceSuitable(physicalDevice);
+	});
+	if (it == physicalDevices.end()) {
 		throw std::runtime_error("failed to find a suitable GPU!");
 	}
 
-	vkGetPhysicalDeviceProperties(physicalDevice, &properties);
-	std::cout << "physical device: " << properties.deviceName << std::endl;
+	// TODO: Implement a scoring system to select the most suitable GPU.
+	// Currently, it picks the first one that meets the minimum requirements.
+	// A more robust approach would evaluate deviceType (Discrete > Integrated),
+	// VRAM capacity, and limits.maxImageDimension2D to assign a quality score.
+
+	physicalDevice = *it;
 }
 
 void VulkanDevice::createLogicalDevice()
 {
-	QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
+	QueueFamilyIndices indices = findQueueFamilies(*physicalDevice);
 
 	std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
 	std::set<uint32_t>                   uniqueQueueFamilies = {indices.graphicsFamily, indices.presentFamily};
@@ -142,7 +147,7 @@ void VulkanDevice::createLogicalDevice()
 		createInfo.enabledLayerCount = 0;
 	}
 
-	if (vkCreateDevice(physicalDevice, &createInfo, nullptr, &device_) != VK_SUCCESS) {
+	if (vkCreateDevice(*physicalDevice, &createInfo, nullptr, &device_) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create logical device!");
 	}
 
@@ -170,23 +175,61 @@ void VulkanDevice::createSurface()
 	window.createWindowSurface(*instance, &surface_);
 }
 
-bool VulkanDevice::isDeviceSuitable(VkPhysicalDevice device)
+bool VulkanDevice::isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice)
 {
-	QueueFamilyIndices indices = findQueueFamilies(device);
-
-	bool extensionsSupported = checkDeviceExtensionSupport(device);
-
-	bool swapChainAdequate = false;
+	bool supportsVulkan1_3   = hasRequiredApiVersion(physicalDevice);
+	bool supportGraphics     = hasGraphicsSupport(physicalDevice);
+	bool extensionsSupported = hasRequiredExtensions(physicalDevice);
+	bool featuresSupported   = hasRequiredFeatures(physicalDevice);
+	bool swapChainAdequate   = false;
 	if (extensionsSupported) {
-		SwapChainSupportDetails swapChainSupport = querySwapChainSupport(device);
+		SwapChainSupportDetails swapChainSupport = querySwapChainSupport(*physicalDevice);
 		swapChainAdequate                        = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
 	}
 
-	VkPhysicalDeviceFeatures supportedFeatures;
-	vkGetPhysicalDeviceFeatures(device, &supportedFeatures);
+	return supportsVulkan1_3 && supportGraphics && extensionsSupported && featuresSupported && swapChainAdequate;
+}
 
-	return indices.isComplete() && extensionsSupported && swapChainAdequate &&
-	       supportedFeatures.samplerAnisotropy;
+bool VulkanDevice::hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if the physicalDevice supports the Vulkan 1.3 API version
+	return physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
+}
+
+bool VulkanDevice::hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if any of the queue families support graphics operations
+	auto queueFamilies = physicalDevice.getQueueFamilyProperties();
+
+	return std::ranges::any_of(queueFamilies, [](auto const &qfp) {
+		return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics);
+	});
+}
+
+bool VulkanDevice::hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if all required physicalDevice extensions are available
+	auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
+
+	auto isSupported = [&](const char *extensionName) {
+		return std::ranges::any_of(availableDeviceExtensions, [&](auto const &prop) {
+			return std::string_view(prop.extensionName) == extensionName;
+		});
+	};
+
+	return std::ranges::all_of(deviceExtensions, isSupported);
+}
+
+bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const
+{
+	// Check if the physicalDevice supports the required features (dynamic rendering and extended dynamic state)
+	auto features = physicalDevice.template getFeatures2<
+	    vk::PhysicalDeviceFeatures2,
+	    vk::PhysicalDeviceVulkan13Features,
+	    vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+
+	return features.template get<vk::PhysicalDeviceVulkan13Features>().dynamicRendering &&
+	       features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 }
 
 void VulkanDevice::populateDebugMessengerCreateInfo(
@@ -290,27 +333,6 @@ std::vector<const char *> VulkanDevice::getRequiredExtensions()
 	return requiredExtensions;
 }
 
-bool VulkanDevice::checkDeviceExtensionSupport(VkPhysicalDevice device)
-{
-	uint32_t extensionCount;
-	vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
-
-	std::vector<VkExtensionProperties> availableExtensions(extensionCount);
-	vkEnumerateDeviceExtensionProperties(
-	    device,
-	    nullptr,
-	    &extensionCount,
-	    availableExtensions.data());
-
-	std::set<std::string> requiredExtensions(deviceExtensions.begin(), deviceExtensions.end());
-
-	for (const auto &extension : availableExtensions) {
-		requiredExtensions.erase(extension.extensionName);
-	}
-
-	return requiredExtensions.empty();
-}
-
 QueueFamilyIndices VulkanDevice::findQueueFamilies(VkPhysicalDevice device)
 {
 	QueueFamilyIndices indices;
@@ -375,7 +397,7 @@ VkFormat VulkanDevice::findSupportedFormat(
 {
 	for (VkFormat format : candidates) {
 		VkFormatProperties props;
-		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &props);
+		vkGetPhysicalDeviceFormatProperties(*physicalDevice, format, &props);
 
 		if (tiling == VK_IMAGE_TILING_LINEAR && (props.linearTilingFeatures & features) == features) {
 			return format;
@@ -390,7 +412,7 @@ VkFormat VulkanDevice::findSupportedFormat(
 uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
 {
 	VkPhysicalDeviceMemoryProperties memProperties;
-	vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProperties);
+	vkGetPhysicalDeviceMemoryProperties(*physicalDevice, &memProperties);
 	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
 		if ((typeFilter & (1 << i)) &&
 		    (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -10,45 +10,16 @@
 namespace mvr
 {
 
-// local callback functions
-static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
-    VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
-    VkDebugUtilsMessageTypeFlagsEXT             messageType,
-    const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData,
-    void                                       *pUserData)
+// callback functions
+VKAPI_ATTR vk::Bool32 VKAPI_CALL VulkanDevice::debugCallback(
+    vk::DebugUtilsMessageSeverityFlagBitsEXT      severity,
+    vk::DebugUtilsMessageTypeFlagsEXT             type,
+    const vk::DebugUtilsMessengerCallbackDataEXT *pCallbackData,
+    void                                         *pUserData)
 {
-	std::cerr << "validation layer: " << pCallbackData->pMessage << std::endl;
+	std::cerr << "validation layer: type " << to_string(type) << " msg: " << pCallbackData->pMessage << std::endl;
 
-	return VK_FALSE;
-}
-
-VkResult CreateDebugUtilsMessengerEXT(
-    VkInstance                                instance,
-    const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo,
-    const VkAllocationCallbacks              *pAllocator,
-    VkDebugUtilsMessengerEXT                 *pDebugMessenger)
-{
-	auto func = (PFN_vkCreateDebugUtilsMessengerEXT) vkGetInstanceProcAddr(
-	    instance,
-	    "vkCreateDebugUtilsMessengerEXT");
-	if (func != nullptr) {
-		return func(instance, pCreateInfo, pAllocator, pDebugMessenger);
-	} else {
-		return VK_ERROR_EXTENSION_NOT_PRESENT;
-	}
-}
-
-void DestroyDebugUtilsMessengerEXT(
-    VkInstance                   instance,
-    VkDebugUtilsMessengerEXT     debugMessenger,
-    const VkAllocationCallbacks *pAllocator)
-{
-	auto func = (PFN_vkDestroyDebugUtilsMessengerEXT) vkGetInstanceProcAddr(
-	    instance,
-	    "vkDestroyDebugUtilsMessengerEXT");
-	if (func != nullptr) {
-		func(instance, debugMessenger, pAllocator);
-	}
+	return vk::False;
 }
 
 // class member functions
@@ -68,10 +39,6 @@ VulkanDevice::~VulkanDevice()
 	vkDestroyCommandPool(device_, commandPool, nullptr);
 	vkDestroyDevice(device_, nullptr);
 
-	if (enableValidationLayers) {
-		DestroyDebugUtilsMessengerEXT(*instance, debugMessenger, nullptr);
-	}
-
 	vkDestroySurfaceKHR(*instance, surface_, nullptr);
 }
 
@@ -84,7 +51,7 @@ void VulkanDevice::createInstance()
 	    .engineVersion      = VK_MAKE_VERSION(1, 0, 0),
 	    .apiVersion         = vk::ApiVersion14};
 
-	VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo;
+	vk::DebugUtilsMessengerCreateInfoEXT debugCreateInfo;
 	if (enableValidationLayers) {
 		populateDebugMessengerCreateInfo(debugCreateInfo);
 	}
@@ -223,28 +190,26 @@ bool VulkanDevice::isDeviceSuitable(VkPhysicalDevice device)
 }
 
 void VulkanDevice::populateDebugMessengerCreateInfo(
-    VkDebugUtilsMessengerCreateInfoEXT &createInfo)
+    vk::DebugUtilsMessengerCreateInfoEXT &debugInfo)
 {
-	createInfo                 = {};
-	createInfo.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-	createInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-	                             VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-	createInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
-	                         VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
-	                         VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-	createInfo.pfnUserCallback = debugCallback;
-	createInfo.pUserData       = nullptr;        // Optional
+	debugInfo.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning |
+	                            vk::DebugUtilsMessageSeverityFlagBitsEXT::eError;
+	debugInfo.messageType = vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral |
+	                        vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation |
+	                        vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance;
+	debugInfo.pfnUserCallback = debugCallback;
+	debugInfo.pUserData       = nullptr;        // Optional
 }
 
 void VulkanDevice::setupDebugMessenger()
 {
-	if (!enableValidationLayers)
+	if (!enableValidationLayers) {
 		return;
-	VkDebugUtilsMessengerCreateInfoEXT createInfo;
-	populateDebugMessengerCreateInfo(createInfo);
-	if (CreateDebugUtilsMessengerEXT(*instance, &createInfo, nullptr, &debugMessenger) != VK_SUCCESS) {
-		throw std::runtime_error("failed to set up debug messenger!");
 	}
+
+	vk::DebugUtilsMessengerCreateInfoEXT debugInfo;
+	populateDebugMessengerCreateInfo(debugInfo);
+	debugMessenger = instance.createDebugUtilsMessengerEXT(debugInfo);
 }
 
 std::vector<const char *> VulkanDevice::getRequiredLayers()

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -45,7 +45,7 @@ VulkanDevice::~VulkanDevice()
 uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
 {
 	VkPhysicalDeviceMemoryProperties memProperties;
-	vkGetPhysicalDeviceMemoryProperties(*physicalDevice_, &memProperties);
+	vkGetPhysicalDeviceMemoryProperties(*physicalDevice, &memProperties);
 	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
 		if ((typeFilter & (1 << i)) &&
 		    (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
@@ -61,7 +61,7 @@ VkFormat VulkanDevice::findSupportedFormat(
 {
 	for (VkFormat format : candidates) {
 		VkFormatProperties props;
-		vkGetPhysicalDeviceFormatProperties(*physicalDevice_, format, &props);
+		vkGetPhysicalDeviceFormatProperties(*physicalDevice, format, &props);
 
 		if (tiling == VK_IMAGE_TILING_LINEAR && (props.linearTilingFeatures & features) == features) {
 			return format;
@@ -290,10 +290,10 @@ void VulkanDevice::pickPhysicalDevice()
 	if (it == physicalDevices.end()) {
 		throw std::runtime_error("Failed to find a suitable GPU!");
 	} else {
-		physicalDevice_    = *it;
-		queueFamilyIndices = findQueueFamilies(physicalDevice_);
+		physicalDevice     = *it;
+		queueFamilyIndices = findQueueFamilies(physicalDevice);
 
-		vk::PhysicalDeviceProperties deviceProperties = physicalDevice_.getProperties();
+		vk::PhysicalDeviceProperties deviceProperties = physicalDevice.getProperties();
 		std::cout << "Selected GPU: " << deviceProperties.deviceName << std::endl;
 	}
 
@@ -339,7 +339,7 @@ void VulkanDevice::createLogicalDevice()
 	    .ppEnabledExtensionNames = deviceExtensions.data(),
 	};
 
-	device_ = vk::raii::Device(physicalDevice_, deviceCreateInfo);
+	device_ = vk::raii::Device(physicalDevice, deviceCreateInfo);
 
 	graphicsQueue_ = vk::raii::Queue(device_, queueFamilyIndices.graphicsFamily.value(), 0);
 	presentQueue_  = vk::raii::Queue(device_, queueFamilyIndices.presentFamily.value(), 0);
@@ -568,27 +568,10 @@ QueueFamilyIndices VulkanDevice::findQueueFamilies(vk::raii::PhysicalDevice cons
 SwapChainSupportDetails VulkanDevice::querySwapChainSupport(vk::raii::PhysicalDevice const &physicalDevice) const
 {
 	SwapChainSupportDetails details;
-	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(*physicalDevice, *surface_, &details.capabilities);
+	details.capabilities = physicalDevice.getSurfaceCapabilitiesKHR(*surface_);
+	details.formats      = physicalDevice.getSurfaceFormatsKHR(*surface_);
+	details.presentModes = physicalDevice.getSurfacePresentModesKHR(*surface_);
 
-	uint32_t formatCount;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, *surface_, &formatCount, nullptr);
-
-	if (formatCount != 0) {
-		details.formats.resize(formatCount);
-		vkGetPhysicalDeviceSurfaceFormatsKHR(*physicalDevice, *surface_, &formatCount, details.formats.data());
-	}
-
-	uint32_t presentModeCount;
-	vkGetPhysicalDeviceSurfacePresentModesKHR(*physicalDevice, *surface_, &presentModeCount, nullptr);
-
-	if (presentModeCount != 0) {
-		details.presentModes.resize(presentModeCount);
-		vkGetPhysicalDeviceSurfacePresentModesKHR(
-		    *physicalDevice,
-		    *surface_,
-		    &presentModeCount,
-		    details.presentModes.data());
-	}
 	return details;
 }
 

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -1,5 +1,4 @@
 #include "vulkan_device.h"
-#include "vulkan/vulkan.hpp"
 
 // std
 #include <algorithm>

--- a/src/core/vulkan_device.cpp
+++ b/src/core/vulkan_device.cpp
@@ -264,27 +264,26 @@ void VulkanDevice::pickPhysicalDevice()
 		throw std::runtime_error("Failed to find GPUs with Vulkan support!");
 	}
 
-	// Log all available physical devices
+	// Log all available physical devices and find the first suitable one
 	std::cout << "Device count: " << physicalDevices.size() << std::endl;
-	std::cout << "Available GPUs: " << std::endl;
-	for (const auto &device : physicalDevices) {
-		auto props = device.getProperties();
-		std::cout << "   " << props.deviceName << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
+	std::cout << "Available GPUs:" << std::endl;
+	bool found = false;
+	for (const auto &candidate : physicalDevices) {
+		auto props = candidate.getProperties();
+		std::cout << "\t" << props.deviceName << " (Type: " << to_string(props.deviceType) << ")" << std::endl;
+
+		if (!found && isDeviceSuitable(candidate)) {
+			physicalDevice     = candidate;
+			queueFamilyIndices = findQueueFamilies(physicalDevice);
+			found              = true;
+		}
 	}
 
-	// Find the first suitable device
-	auto const it = std::ranges::find_if(physicalDevices, [&](auto const &physicalDevice) {
-		return isDeviceSuitable(physicalDevice);
-	});
-	if (it == physicalDevices.end()) {
+	if (!found) {
 		throw std::runtime_error("Failed to find a suitable GPU!");
-	} else {
-		physicalDevice     = *it;
-		queueFamilyIndices = findQueueFamilies(physicalDevice);
-
-		vk::PhysicalDeviceProperties deviceProperties = physicalDevice.getProperties();
-		std::cout << "Selected GPU: " << deviceProperties.deviceName << std::endl;
 	}
+
+	std::cout << "Selected GPU: " << physicalDevice.getProperties().deviceName << std::endl;
 
 	// TODO: Implement a scoring system to select the most suitable GPU.
 	// Currently, it picks the first one that meets the minimum requirements.
@@ -466,7 +465,7 @@ bool VulkanDevice::hasRequiredApiVersion(vk::raii::PhysicalDevice const &physica
 	// Check if the physicalDevice supports the Vulkan 1.3 API version
 	bool result = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 	if (!result) {
-		std::cerr << " - Does not support Vulkan 1.3 API version" << std::endl;
+		std::cerr << "\t" << " - Does not support Vulkan 1.3 API version" << std::endl;
 	}
 
 	return result;
@@ -478,7 +477,7 @@ bool VulkanDevice::hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDe
 	QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
 	bool               result  = indices.isComplete();
 	if (!result) {
-		std::cerr << " - Missing required queue families" << std::endl;
+		std::cerr << "\t" << " - Missing required queue families" << std::endl;
 	}
 
 	return result;
@@ -497,7 +496,7 @@ bool VulkanDevice::hasRequiredExtensions(vk::raii::PhysicalDevice const &physica
 
 	bool result = std::ranges::all_of(deviceExtensions, isSupported);
 	if (!result) {
-		std::cerr << " - Missing required extensions" << std::endl;
+		std::cerr << "\t" << " - Missing required extensions" << std::endl;
 	}
 
 	return result;
@@ -514,7 +513,7 @@ bool VulkanDevice::hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalD
 	bool result = features.template get<vk::PhysicalDeviceVulkan13Features>().dynamicRendering &&
 	              features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 	if (!result) {
-		std::cerr << " - Does not support required features" << std::endl;
+		std::cerr << "\t" << " - Does not support required features" << std::endl;
 	}
 
 	return result;
@@ -525,7 +524,7 @@ bool VulkanDevice::hasSwapchainSupport(vk::raii::PhysicalDevice const &physicalD
 	SwapChainSupportDetails swapChainSupport = querySwapChainSupport(physicalDevice);
 	bool                    result           = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
 	if (!result) {
-		std::cerr << " - Does not support required swapchain support" << std::endl;
+		std::cerr << "\t" << " - Does not support required swapchain support" << std::endl;
 	}
 
 	return result;

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -37,7 +37,6 @@ class VulkanDevice
 
 	// Constructor & Destructor
 	VulkanDevice(Window &window);
-	~VulkanDevice();
 
 	// Not copyable or movable
 	VulkanDevice(const VulkanDevice &)       = delete;
@@ -59,7 +58,7 @@ class VulkanDevice
 	// Getters
 	VkCommandPool getCommandPool()
 	{
-		return commandPool;
+		return *commandPool;
 	}
 	vk::raii::Device &device()
 	{
@@ -114,7 +113,7 @@ class VulkanDevice
 	vk::raii::Queue graphicsQueue_ = nullptr;
 	vk::raii::Queue presentQueue_  = nullptr;
 
-	VkCommandPool commandPool;
+	vk::raii::CommandPool commandPool = nullptr;
 
 	// Private Init Methods
 	void createInstance();

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -71,13 +71,13 @@ class VulkanDevice
 	{
 		return *surface_;
 	}
-	VkQueue graphicsQueue()
+	vk::raii::Queue &graphicsQueue()
 	{
-		return *graphicsQueue_;
+		return graphicsQueue_;
 	}
-	VkQueue presentQueue()
+	vk::raii::Queue &presentQueue()
 	{
-		return *presentQueue_;
+		return presentQueue_;
 	}
 	SwapChainSupportDetails getSwapChainSupport()
 	{

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -33,7 +33,9 @@ class VulkanDevice
 #else
 	const bool enableValidationLayers = true;
 #endif
+	VkPhysicalDeviceProperties properties;
 
+	// Constructor & Destructor
 	VulkanDevice(Window &window);
 	~VulkanDevice();
 
@@ -43,6 +45,7 @@ class VulkanDevice
 	VulkanDevice(VulkanDevice &&)            = delete;
 	VulkanDevice &operator=(VulkanDevice &&) = delete;
 
+	// Getters  (inline)
 	VkCommandPool getCommandPool()
 	{
 		return commandPool;
@@ -63,16 +66,17 @@ class VulkanDevice
 	{
 		return presentQueue_;
 	}
-
 	SwapChainSupportDetails getSwapChainSupport()
 	{
 		return querySwapChainSupport(*physicalDevice);
 	}
-	uint32_t           findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
 	QueueFamilyIndices findPhysicalQueueFamilies()
 	{
 		return findQueueFamilies(*physicalDevice);
 	}
+
+	// Utilities
+	uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
 	VkFormat findSupportedFormat(
 	    const std::vector<VkFormat> &candidates, VkImageTiling tiling, VkFormatFeatureFlags features);
 
@@ -95,34 +99,7 @@ class VulkanDevice
 	    VkImage                 &image,
 	    VkDeviceMemory          &imageMemory);
 
-	VkPhysicalDeviceProperties properties;
-
   private:
-	void createInstance();
-	void setupDebugMessenger();
-	void createSurface();
-	void pickPhysicalDevice();
-	void createLogicalDevice();
-	void createCommandPool();
-
-	// helper functions
-	bool                      isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice);
-	std::vector<const char *> getRequiredExtensions();
-	std::vector<const char *> getRequiredLayers();
-	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
-	void                      populateDebugMessengerCreateInfo(vk::DebugUtilsMessengerCreateInfoEXT &createInfo);
-	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
-	static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(
-	    vk::DebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
-	    vk::DebugUtilsMessageTypeFlagsEXT             messageType,
-	    const vk::DebugUtilsMessengerCallbackDataEXT *pCallbackData,
-	    void                                         *pUserData);
-	bool isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice) const;
-	bool hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const;
-	bool hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const;
-	bool hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const;
-	bool hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const;
-
 	vk::raii::Context                context;
 	vk::raii::Instance               instance       = nullptr;
 	vk::raii::DebugUtilsMessengerEXT debugMessenger = nullptr;
@@ -141,6 +118,30 @@ class VulkanDevice
 #else
 	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName};
 #endif
+
+	void createInstance();
+	void setupDebugMessenger();
+	void createSurface();
+	void pickPhysicalDevice();
+	void createLogicalDevice();
+	void createCommandPool();
+
+	// helper functions
+	void              populateDebugMessengerCreateInfo(vk::DebugUtilsMessengerCreateInfoEXT &createInfo);
+	static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(
+	    vk::DebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
+	    vk::DebugUtilsMessageTypeFlagsEXT             messageType,
+	    const vk::DebugUtilsMessengerCallbackDataEXT *pCallbackData,
+	    void                                         *pUserData);
+	std::vector<const char *> getRequiredLayers();
+	std::vector<const char *> getRequiredExtensions();
+	bool                      isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice);
+	bool                      hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const;
+	bool                      hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const;
+	bool                      hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const;
+	bool                      hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const;
+	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
+	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
 };
 
 }        // namespace mvr

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -108,7 +108,7 @@ class VulkanDevice
 	// helper functions
 	bool                      isDeviceSuitable(VkPhysicalDevice device);
 	std::vector<const char *> getRequiredExtensions();
-	bool                      checkValidationLayerSupport();
+	void                      checkValidationLayerSupport();
 	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
 	void                      populateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT &createInfo);
 	void                      hasGlfwRequiredInstanceExtensions();

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -108,10 +108,9 @@ class VulkanDevice
 	// helper functions
 	bool                      isDeviceSuitable(VkPhysicalDevice device);
 	std::vector<const char *> getRequiredExtensions();
-	void                      checkValidationLayerSupport();
+	std::vector<const char *> getRequiredLayers();
 	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
 	void                      populateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT &createInfo);
-	void                      hasGlfwRequiredInstanceExtensions();
 	bool                      checkDeviceExtensionSupport(VkPhysicalDevice device);
 	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
 

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -45,20 +45,19 @@ class VulkanDevice
 	VulkanDevice &operator=(VulkanDevice &&) = delete;
 
 	// Public Methods
-	uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
+	uint32_t findMemoryType(uint32_t typeFilter, vk::MemoryPropertyFlags properties);
 	VkFormat findSupportedFormat(const std::vector<VkFormat> &candidates, VkImageTiling tiling, VkFormatFeatureFlags features);
 
-	void            createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkBuffer &buffer, VkDeviceMemory &bufferMemory);
 	VkCommandBuffer beginSingleTimeCommands();
 	void            endSingleTimeCommands(VkCommandBuffer commandBuffer);
 	void            copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
 	void            copyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height, uint32_t layerCount);
-	void            createImageWithInfo(const VkImageCreateInfo &imageInfo, VkMemoryPropertyFlags properties, VkImage &image, VkDeviceMemory &imageMemory);
+	void            createImageWithInfo(const VkImageCreateInfo &imageInfo, vk::MemoryPropertyFlags properties, VkImage &image, VkDeviceMemory &imageMemory);
 
 	// Getters
-	VkCommandPool getCommandPool()
+	vk::raii::CommandPool &getCommandPool()
 	{
-		return *commandPool;
+		return commandPool;
 	}
 	vk::raii::Device &device()
 	{

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -2,8 +2,7 @@
 
 #include "window.h"
 
-// std lib headers
-#include <string>
+// std
 #include <vector>
 
 namespace mvr
@@ -112,7 +111,7 @@ class VulkanDevice
 	bool                      checkValidationLayerSupport();
 	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
 	void                      populateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT &createInfo);
-	void                      hasGflwRequiredInstanceExtensions();
+	void                      hasGlfwRequiredInstanceExtensions();
 	bool                      checkDeviceExtensionSupport(VkPhysicalDevice device);
 	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
 

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -30,7 +30,7 @@ class VulkanDevice
 #ifdef NDEBUG
 	const bool enableValidationLayers = false;
 #else
-	const bool enableValidationLayers = true;
+	const bool                      enableValidationLayers = true;
 #endif
 	VkPhysicalDeviceProperties properties;
 
@@ -117,9 +117,9 @@ class VulkanDevice
 
 	const std::vector<const char *> validationLayers = {"VK_LAYER_KHRONOS_validation"};
 #ifdef __APPLE__
-	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName, vk::KHRPortabilitySubsetExtensionName};
+	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName, "VK_KHR_portability_subset"};
 #else
-	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName};
+	const std::vector<const char *> deviceExtensions       = {vk::KHRSwapchainExtensionName};
 #endif
 
 	void createInstance();

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -15,13 +15,12 @@ struct SwapChainSupportDetails {
 };
 
 struct QueueFamilyIndices {
-	uint32_t graphicsFamily;
-	uint32_t presentFamily;
-	bool     graphicsFamilyHasValue = false;
-	bool     presentFamilyHasValue  = false;
-	bool     isComplete()
+	std::optional<uint32_t> graphicsFamily;
+	std::optional<uint32_t> presentFamily;
+	// TODO: std::optional<uint32_t> computeFamily;
+	bool isComplete()
 	{
-		return graphicsFamilyHasValue && presentFamilyHasValue;
+		return graphicsFamily.has_value() && presentFamily.has_value();
 	}
 };
 
@@ -52,7 +51,7 @@ class VulkanDevice
 	}
 	VkDevice device()
 	{
-		return device_;
+		return *device_;
 	}
 	VkSurfaceKHR surface()
 	{
@@ -60,11 +59,11 @@ class VulkanDevice
 	}
 	VkQueue graphicsQueue()
 	{
-		return graphicsQueue_;
+		return *graphicsQueue_;
 	}
 	VkQueue presentQueue()
 	{
-		return presentQueue_;
+		return *presentQueue_;
 	}
 	SwapChainSupportDetails getSwapChainSupport()
 	{
@@ -72,7 +71,7 @@ class VulkanDevice
 	}
 	QueueFamilyIndices findPhysicalQueueFamilies()
 	{
-		return findQueueFamilies(*physicalDevice);
+		return findQueueFamilies(physicalDevice);
 	}
 
 	// Utilities
@@ -107,14 +106,18 @@ class VulkanDevice
 	Window                          &window;
 	VkCommandPool                    commandPool;
 
-	VkDevice     device_;
-	VkSurfaceKHR surface_;
-	VkQueue      graphicsQueue_;
-	VkQueue      presentQueue_;
+	vk::raii::Device device_ = nullptr;
+	VkSurfaceKHR     surface_;
+
+	vk::raii::Queue graphicsQueue_ = nullptr;
+	vk::raii::Queue presentQueue_  = nullptr;
+
+	// queue families indices
+	QueueFamilyIndices queueFamilyIndices;
 
 	const std::vector<const char *> validationLayers = {"VK_LAYER_KHRONOS_validation"};
 #ifdef __APPLE__
-	const std::vector<const char *> deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, "VK_KHR_portability_subset"};
+	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName, vk::KHRPortabilitySubsetExtensionName};
 #else
 	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName};
 #endif
@@ -140,8 +143,8 @@ class VulkanDevice
 	bool                      hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const;
 	bool                      hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const;
 	bool                      hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const;
+	QueueFamilyIndices        findQueueFamilies(vk::raii::PhysicalDevice const &physicalDevice);
 	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
-	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
 };
 
 }        // namespace mvr

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -110,16 +110,21 @@ class VulkanDevice
 	std::vector<const char *> getRequiredExtensions();
 	std::vector<const char *> getRequiredLayers();
 	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
-	void                      populateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT &createInfo);
+	void                      populateDebugMessengerCreateInfo(vk::DebugUtilsMessengerCreateInfoEXT &createInfo);
 	bool                      checkDeviceExtensionSupport(VkPhysicalDevice device);
 	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
+	static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(
+	    vk::DebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
+	    vk::DebugUtilsMessageTypeFlagsEXT             messageType,
+	    const vk::DebugUtilsMessengerCallbackDataEXT *pCallbackData,
+	    void                                         *pUserData);
 
-	vk::raii::Context        context;
-	vk::raii::Instance       instance = nullptr;
-	VkDebugUtilsMessengerEXT debugMessenger;
-	VkPhysicalDevice         physicalDevice = VK_NULL_HANDLE;
-	Window                  &window;
-	VkCommandPool            commandPool;
+	vk::raii::Context                context;
+	vk::raii::Instance               instance       = nullptr;
+	vk::raii::DebugUtilsMessengerEXT debugMessenger = nullptr;
+	VkPhysicalDevice                 physicalDevice = VK_NULL_HANDLE;
+	Window                          &window;
+	VkCommandPool                    commandPool;
 
 	VkDevice     device_;
 	VkSurfaceKHR surface_;

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -30,7 +30,7 @@ class VulkanDevice
 #ifdef NDEBUG
 	const bool enableValidationLayers = false;
 #else
-	const bool                      enableValidationLayers = true;
+	const bool enableValidationLayers = true;
 #endif
 	VkPhysicalDeviceProperties properties;
 
@@ -55,7 +55,7 @@ class VulkanDevice
 	}
 	VkSurfaceKHR surface()
 	{
-		return surface_;
+		return *surface_;
 	}
 	VkQueue graphicsQueue()
 	{
@@ -106,8 +106,8 @@ class VulkanDevice
 	Window                          &window;
 	VkCommandPool                    commandPool;
 
-	vk::raii::Device device_ = nullptr;
-	VkSurfaceKHR     surface_;
+	vk::raii::Device     device_  = nullptr;
+	vk::raii::SurfaceKHR surface_ = nullptr;
 
 	vk::raii::Queue graphicsQueue_ = nullptr;
 	vk::raii::Queue presentQueue_  = nullptr;
@@ -119,7 +119,7 @@ class VulkanDevice
 #ifdef __APPLE__
 	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName, "VK_KHR_portability_subset"};
 #else
-	const std::vector<const char *> deviceExtensions       = {vk::KHRSwapchainExtensionName};
+	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName};
 #endif
 
 	void createInstance();

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -66,12 +66,12 @@ class VulkanDevice
 
 	SwapChainSupportDetails getSwapChainSupport()
 	{
-		return querySwapChainSupport(physicalDevice);
+		return querySwapChainSupport(*physicalDevice);
 	}
 	uint32_t           findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
 	QueueFamilyIndices findPhysicalQueueFamilies()
 	{
-		return findQueueFamilies(physicalDevice);
+		return findQueueFamilies(*physicalDevice);
 	}
 	VkFormat findSupportedFormat(
 	    const std::vector<VkFormat> &candidates, VkImageTiling tiling, VkFormatFeatureFlags features);
@@ -106,23 +106,27 @@ class VulkanDevice
 	void createCommandPool();
 
 	// helper functions
-	bool                      isDeviceSuitable(VkPhysicalDevice device);
+	bool                      isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice);
 	std::vector<const char *> getRequiredExtensions();
 	std::vector<const char *> getRequiredLayers();
 	QueueFamilyIndices        findQueueFamilies(VkPhysicalDevice device);
 	void                      populateDebugMessengerCreateInfo(vk::DebugUtilsMessengerCreateInfoEXT &createInfo);
-	bool                      checkDeviceExtensionSupport(VkPhysicalDevice device);
 	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
 	static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(
 	    vk::DebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
 	    vk::DebugUtilsMessageTypeFlagsEXT             messageType,
 	    const vk::DebugUtilsMessengerCallbackDataEXT *pCallbackData,
 	    void                                         *pUserData);
+	bool isDeviceSuitable(vk::raii::PhysicalDevice const &physicalDevice) const;
+	bool hasRequiredApiVersion(vk::raii::PhysicalDevice const &physicalDevice) const;
+	bool hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const;
+	bool hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const;
+	bool hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const;
 
 	vk::raii::Context                context;
 	vk::raii::Instance               instance       = nullptr;
 	vk::raii::DebugUtilsMessengerEXT debugMessenger = nullptr;
-	VkPhysicalDevice                 physicalDevice = VK_NULL_HANDLE;
+	vk::raii::PhysicalDevice         physicalDevice = nullptr;
 	Window                          &window;
 	VkCommandPool                    commandPool;
 
@@ -135,7 +139,7 @@ class VulkanDevice
 #ifdef __APPLE__
 	const std::vector<const char *> deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, "VK_KHR_portability_subset"};
 #else
-	const std::vector<const char *> deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName};
 #endif
 };
 

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -32,7 +32,7 @@ class VulkanDevice
 #ifdef NDEBUG
 	const bool enableValidationLayers = false;
 #else
-	const bool                      enableValidationLayers = true;
+	const bool enableValidationLayers = true;
 #endif
 
 	VulkanDevice(Window &window);
@@ -116,7 +116,8 @@ class VulkanDevice
 	bool                      checkDeviceExtensionSupport(VkPhysicalDevice device);
 	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
 
-	VkInstance               instance;
+	vk::raii::Context        context;
+	vk::raii::Instance       instance = nullptr;
 	VkDebugUtilsMessengerEXT debugMessenger;
 	VkPhysicalDevice         physicalDevice = VK_NULL_HANDLE;
 	Window                  &window;
@@ -131,7 +132,7 @@ class VulkanDevice
 #ifdef __APPLE__
 	const std::vector<const char *> deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, "VK_KHR_portability_subset"};
 #else
-	const std::vector<const char *> deviceExtensions       = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+	const std::vector<const char *> deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
 #endif
 };
 

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -67,7 +67,7 @@ class VulkanDevice
 	}
 	SwapChainSupportDetails getSwapChainSupport()
 	{
-		return querySwapChainSupport(*physicalDevice);
+		return querySwapChainSupport(physicalDevice);
 	}
 	QueueFamilyIndices findPhysicalQueueFamilies()
 	{
@@ -143,8 +143,9 @@ class VulkanDevice
 	bool                      hasGraphicsSupport(vk::raii::PhysicalDevice const &physicalDevice) const;
 	bool                      hasRequiredExtensions(vk::raii::PhysicalDevice const &physicalDevice) const;
 	bool                      hasRequiredFeatures(vk::raii::PhysicalDevice const &physicalDevice) const;
-	QueueFamilyIndices        findQueueFamilies(vk::raii::PhysicalDevice const &physicalDevice);
-	SwapChainSupportDetails   querySwapChainSupport(VkPhysicalDevice device);
+	bool                      hasSwapchainSupport(vk::raii::PhysicalDevice const &physicalDevice) const;
+	QueueFamilyIndices        findQueueFamilies(vk::raii::PhysicalDevice const &physicalDevice) const;
+	SwapChainSupportDetails   querySwapChainSupport(vk::raii::PhysicalDevice const &physicalDevice) const;
 };
 
 }        // namespace mvr

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -53,6 +53,10 @@ class VulkanDevice
 	{
 		return *device_;
 	}
+	vk::raii::PhysicalDevice &physicalDevice()
+	{
+		return physicalDevice_;
+	}
 	VkSurfaceKHR surface()
 	{
 		return *surface_;
@@ -67,11 +71,11 @@ class VulkanDevice
 	}
 	SwapChainSupportDetails getSwapChainSupport()
 	{
-		return querySwapChainSupport(physicalDevice);
+		return querySwapChainSupport(physicalDevice_);
 	}
 	QueueFamilyIndices findPhysicalQueueFamilies()
 	{
-		return findQueueFamilies(physicalDevice);
+		return findQueueFamilies(physicalDevice_);
 	}
 
 	// Utilities
@@ -100,9 +104,9 @@ class VulkanDevice
 
   private:
 	vk::raii::Context                context;
-	vk::raii::Instance               instance       = nullptr;
-	vk::raii::DebugUtilsMessengerEXT debugMessenger = nullptr;
-	vk::raii::PhysicalDevice         physicalDevice = nullptr;
+	vk::raii::Instance               instance        = nullptr;
+	vk::raii::DebugUtilsMessengerEXT debugMessenger  = nullptr;
+	vk::raii::PhysicalDevice         physicalDevice_ = nullptr;
 	Window                          &window;
 	VkCommandPool                    commandPool;
 

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -27,6 +27,7 @@ struct QueueFamilyIndices {
 class VulkanDevice
 {
   public:
+	// Variables
 #ifdef NDEBUG
 	const bool enableValidationLayers = false;
 #else
@@ -44,7 +45,18 @@ class VulkanDevice
 	VulkanDevice(VulkanDevice &&)            = delete;
 	VulkanDevice &operator=(VulkanDevice &&) = delete;
 
-	// Getters  (inline)
+	// Public Methods
+	uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
+	VkFormat findSupportedFormat(const std::vector<VkFormat> &candidates, VkImageTiling tiling, VkFormatFeatureFlags features);
+
+	void            createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkBuffer &buffer, VkDeviceMemory &bufferMemory);
+	VkCommandBuffer beginSingleTimeCommands();
+	void            endSingleTimeCommands(VkCommandBuffer commandBuffer);
+	void            copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
+	void            copyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height, uint32_t layerCount);
+	void            createImageWithInfo(const VkImageCreateInfo &imageInfo, VkMemoryPropertyFlags properties, VkImage &image, VkDeviceMemory &imageMemory);
+
+	// Getters
 	VkCommandPool getCommandPool()
 	{
 		return commandPool;
@@ -78,54 +90,33 @@ class VulkanDevice
 		return findQueueFamilies(physicalDevice);
 	}
 
-	// Utilities
-	uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
-	VkFormat findSupportedFormat(
-	    const std::vector<VkFormat> &candidates, VkImageTiling tiling, VkFormatFeatureFlags features);
-
-	// Buffer Helper Functions
-	void createBuffer(
-	    VkDeviceSize          size,
-	    VkBufferUsageFlags    usage,
-	    VkMemoryPropertyFlags properties,
-	    VkBuffer             &buffer,
-	    VkDeviceMemory       &bufferMemory);
-	VkCommandBuffer beginSingleTimeCommands();
-	void            endSingleTimeCommands(VkCommandBuffer commandBuffer);
-	void            copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
-	void            copyBufferToImage(
-	               VkBuffer buffer, VkImage image, uint32_t width, uint32_t height, uint32_t layerCount);
-
-	void createImageWithInfo(
-	    const VkImageCreateInfo &imageInfo,
-	    VkMemoryPropertyFlags    properties,
-	    VkImage                 &image,
-	    VkDeviceMemory          &imageMemory);
-
   private:
-	vk::raii::Context                context;
-	vk::raii::Instance               instance       = nullptr;
-	vk::raii::DebugUtilsMessengerEXT debugMessenger = nullptr;
-	vk::raii::PhysicalDevice         physicalDevice = nullptr;
-	Window                          &window;
-	VkCommandPool                    commandPool;
-
-	vk::raii::Device     device_  = nullptr;
-	vk::raii::SurfaceKHR surface_ = nullptr;
-
-	vk::raii::Queue graphicsQueue_ = nullptr;
-	vk::raii::Queue presentQueue_  = nullptr;
-
-	// queue families indices
-	QueueFamilyIndices queueFamilyIndices;
+	// Variables
+	Window &window;
 
 	const std::vector<const char *> validationLayers = {"VK_LAYER_KHRONOS_validation"};
+
 #ifdef __APPLE__
 	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName, "VK_KHR_portability_subset"};
 #else
 	const std::vector<const char *> deviceExtensions = {vk::KHRSwapchainExtensionName};
 #endif
 
+	QueueFamilyIndices queueFamilyIndices;
+
+	vk::raii::Context                context;
+	vk::raii::Instance               instance       = nullptr;
+	vk::raii::DebugUtilsMessengerEXT debugMessenger = nullptr;
+	vk::raii::SurfaceKHR             surface_       = nullptr;
+	vk::raii::PhysicalDevice         physicalDevice = nullptr;
+	vk::raii::Device                 device_        = nullptr;
+
+	vk::raii::Queue graphicsQueue_ = nullptr;
+	vk::raii::Queue presentQueue_  = nullptr;
+
+	VkCommandPool commandPool;
+
+	// Private Init Methods
 	void createInstance();
 	void setupDebugMessenger();
 	void createSurface();
@@ -133,7 +124,7 @@ class VulkanDevice
 	void createLogicalDevice();
 	void createCommandPool();
 
-	// helper functions
+	// Helper Methods
 	void              populateDebugMessengerCreateInfo(vk::DebugUtilsMessengerCreateInfoEXT &createInfo);
 	static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(
 	    vk::DebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,

--- a/src/core/vulkan_device.h
+++ b/src/core/vulkan_device.h
@@ -9,9 +9,9 @@ namespace mvr
 {
 
 struct SwapChainSupportDetails {
-	VkSurfaceCapabilitiesKHR        capabilities;
-	std::vector<VkSurfaceFormatKHR> formats;
-	std::vector<VkPresentModeKHR>   presentModes;
+	vk::SurfaceCapabilitiesKHR        capabilities;
+	std::vector<vk::SurfaceFormatKHR> formats;
+	std::vector<vk::PresentModeKHR>   presentModes;
 };
 
 struct QueueFamilyIndices {
@@ -49,13 +49,13 @@ class VulkanDevice
 	{
 		return commandPool;
 	}
-	VkDevice device()
+	vk::raii::Device &device()
 	{
-		return *device_;
+		return device_;
 	}
-	vk::raii::PhysicalDevice &physicalDevice()
+	Window &getWindow()
 	{
-		return physicalDevice_;
+		return window;
 	}
 	VkSurfaceKHR surface()
 	{
@@ -71,11 +71,11 @@ class VulkanDevice
 	}
 	SwapChainSupportDetails getSwapChainSupport()
 	{
-		return querySwapChainSupport(physicalDevice_);
+		return querySwapChainSupport(physicalDevice);
 	}
 	QueueFamilyIndices findPhysicalQueueFamilies()
 	{
-		return findQueueFamilies(physicalDevice_);
+		return findQueueFamilies(physicalDevice);
 	}
 
 	// Utilities
@@ -104,9 +104,9 @@ class VulkanDevice
 
   private:
 	vk::raii::Context                context;
-	vk::raii::Instance               instance        = nullptr;
-	vk::raii::DebugUtilsMessengerEXT debugMessenger  = nullptr;
-	vk::raii::PhysicalDevice         physicalDevice_ = nullptr;
+	vk::raii::Instance               instance       = nullptr;
+	vk::raii::DebugUtilsMessengerEXT debugMessenger = nullptr;
+	vk::raii::PhysicalDevice         physicalDevice = nullptr;
 	Window                          &window;
 	VkCommandPool                    commandPool;
 

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -22,9 +22,14 @@ bool Window::shouldClose()
 	return glfwWindowShouldClose(window);
 }
 
-VkExtent2D Window::getExtent()
+vk::Extent2D Window::getExtent()
 {
 	return {width, height};
+}
+
+void Window::getFrameBufferSize(int *width, int *height)
+{
+	glfwGetFramebufferSize(window, width, height);
 }
 
 void Window::createWindowSurface(VkInstance instance, VkSurfaceKHR *surface)

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -30,7 +30,7 @@ VkExtent2D Window::getExtent()
 void Window::createWindowSurface(VkInstance instance, VkSurfaceKHR *surface)
 {
 	if (glfwCreateWindowSurface(instance, window, nullptr, surface) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create window surface");
+		throw std::runtime_error("Failed to create window surface!");
 	}
 }
 

--- a/src/core/window.h
+++ b/src/core/window.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include <vulkan/vulkan.h>
-#define GLFW_INCLUDE_NONE
+#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+#include <vulkan/vulkan_raii.hpp>
+
 #include <GLFW/glfw3.h>
 
+// std
 #include <string>
 
 namespace mvr

--- a/src/core/window.h
+++ b/src/core/window.h
@@ -20,9 +20,11 @@ class Window
 	Window(const Window &)            = delete;
 	Window &operator=(const Window &) = delete;
 
-	bool       shouldClose();
-	VkExtent2D getExtent();
-	void       createWindowSurface(VkInstance instance, VkSurfaceKHR *surface);
+	bool         shouldClose();
+	vk::Extent2D getExtent();
+	void         getFrameBufferSize(int *width, int *height);
+
+	void createWindowSurface(VkInstance instance, VkSurfaceKHR *surface);
 
   private:
 	GLFWwindow    *window;

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -1,4 +1,5 @@
 #include "first_app.h"
+#include "vulkan/vulkan.hpp"
 
 // std
 #include <array>
@@ -18,7 +19,6 @@ FirstApp::FirstApp()
 
 FirstApp::~FirstApp()
 {
-	vkDestroyPipelineLayout(*device.device(), pipelineLayout, nullptr);
 }
 
 void FirstApp::run()
@@ -44,23 +44,20 @@ void FirstApp::loadModel()
 
 void FirstApp::createPipelineLayout()
 {
-	VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
-	pipelineLayoutInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-	pipelineLayoutInfo.setLayoutCount         = 0;
-	pipelineLayoutInfo.pSetLayouts            = nullptr;
-	pipelineLayoutInfo.pushConstantRangeCount = 0;
-	pipelineLayoutInfo.pPushConstantRanges    = nullptr;
+	vk::PipelineLayoutCreateInfo pipelineLayoutInfo = {
+	    .setLayoutCount         = 0,
+	    .pushConstantRangeCount = 0,
+	};
 
-	if (vkCreatePipelineLayout(*device.device(), &pipelineLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create pipeline layout!");
-	}
+	pipelineLayout = vk::raii::PipelineLayout(device.device(), pipelineLayoutInfo);
 }
 
 void FirstApp::createPipeline()
 {
-	auto pipelineConfig           = Pipeline::defaultPipelineConfigInfo(swapChain.width(), swapChain.height());
-	pipelineConfig.pipelineLayout = pipelineLayout;
-	pipelineConfig.renderPass     = swapChain.getRenderPass();
+	auto pipelineConfig           = Pipeline::defaultPipelineConfigInfo(swapChain.width(),
+	                                                                    swapChain.height(),
+	                                                                    swapChain.getSwapChainSurfaceFormat());
+	pipelineConfig.pipelineLayout = *pipelineLayout;
 	pipeline                      = std::make_unique<Pipeline>(device,
 	                                                           "../shaders/simple_shader.vert.spv",
 	                                                           "../shaders/simple_shader.frag.spv",

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -18,7 +18,7 @@ FirstApp::FirstApp()
 
 FirstApp::~FirstApp()
 {
-	vkDestroyPipelineLayout(device.device(), pipelineLayout, nullptr);
+	vkDestroyPipelineLayout(*device.device(), pipelineLayout, nullptr);
 }
 
 void FirstApp::run()
@@ -28,7 +28,7 @@ void FirstApp::run()
 		drawFrame();
 	}
 
-	vkDeviceWaitIdle(device.device());
+	vkDeviceWaitIdle(*device.device());
 }
 
 void FirstApp::loadModel()
@@ -51,7 +51,7 @@ void FirstApp::createPipelineLayout()
 	pipelineLayoutInfo.pushConstantRangeCount = 0;
 	pipelineLayoutInfo.pPushConstantRanges    = nullptr;
 
-	if (vkCreatePipelineLayout(device.device(), &pipelineLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
+	if (vkCreatePipelineLayout(*device.device(), &pipelineLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
 		throw std::runtime_error("failed to create pipeline layout!");
 	}
 }
@@ -77,7 +77,7 @@ void FirstApp::createCommandBuffers()
 	allocInfo.commandPool        = device.getCommandPool();
 	allocInfo.commandBufferCount = static_cast<uint32_t>(commandBuffers.size());
 
-	if (vkAllocateCommandBuffers(device.device(), &allocInfo, commandBuffers.data()) != VK_SUCCESS) {
+	if (vkAllocateCommandBuffers(*device.device(), &allocInfo, commandBuffers.data()) != VK_SUCCESS) {
 		throw std::runtime_error("failed to allocate command buffers!");
 	}
 

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -26,7 +26,7 @@ void FirstApp::run()
 		drawFrame();
 	}
 
-	vkDeviceWaitIdle(*device.device());
+	device.device().waitIdle();
 }
 
 void FirstApp::loadModel()
@@ -86,7 +86,7 @@ void FirstApp::recordCommandBuffer(uint32_t imageIndex)
 	    vk::PipelineStageFlagBits2::eColorAttachmentOutput         // dstStage
 	);
 
-	vk::ClearValue              clearColor     = vk::ClearColorValue(0.0f, 0.0f, 0.0f, 1.0f);
+	vk::ClearValue              clearColor     = vk::ClearColorValue(0.1f, 0.1f, 0.1f, 1.0f);
 	vk::RenderingAttachmentInfo attachmentInfo = {
 	    .imageView   = swapChain.getImageView(imageIndex),
 	    .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <stdexcept>
+#include <vulkan/vulkan_core.h>
 
 namespace mvr
 {
@@ -53,9 +54,7 @@ void FirstApp::createPipelineLayout()
 
 void FirstApp::createPipeline()
 {
-	auto pipelineConfig           = Pipeline::defaultPipelineConfigInfo(swapChain.width(),
-	                                                                    swapChain.height(),
-	                                                                    swapChain.getSwapChainSurfaceFormat());
+	auto pipelineConfig           = Pipeline::defaultPipelineConfigInfo(swapChain.getSwapChainSurfaceFormat());
 	pipelineConfig.pipelineLayout = *pipelineLayout;
 	pipeline                      = std::make_unique<Pipeline>(device,
 	                                                           "../shaders/simple_shader.vert.spv",
@@ -65,50 +64,103 @@ void FirstApp::createPipeline()
 
 void FirstApp::createCommandBuffers()
 {
-	commandBuffers.resize(swapChain.imageCount());
+	vk::CommandBufferAllocateInfo allocInfo = {
+	    .commandPool        = device.getCommandPool(),
+	    .level              = vk::CommandBufferLevel::ePrimary,
+	    .commandBufferCount = SwapChain::MAX_FRAMES_IN_FLIGHT,
+	};
 
-	VkCommandBufferAllocateInfo allocInfo{};
-	allocInfo.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-	allocInfo.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-	allocInfo.commandPool        = device.getCommandPool();
-	allocInfo.commandBufferCount = static_cast<uint32_t>(commandBuffers.size());
+	commandBuffers = vk::raii::CommandBuffers(device.device(), allocInfo);
+}
 
-	if (vkAllocateCommandBuffers(*device.device(), &allocInfo, commandBuffers.data()) != VK_SUCCESS) {
-		throw std::runtime_error("failed to allocate command buffers!");
-	}
+void FirstApp::recordCommandBuffer(uint32_t imageIndex)
+{
+	auto &commandBuffer = commandBuffers[frameIndex];
+	commandBuffer.begin({});
 
-	for (int i = 0; i < commandBuffers.size(); i++) {
-		VkCommandBufferBeginInfo beginInfo{};
-		beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+	transitionImageLayout(
+	    imageIndex,
+	    vk::ImageLayout::eUndefined,
+	    vk::ImageLayout::eColorAttachmentOptimal,
+	    vk::AccessFlagBits2{},                                     // srcAccessMask
+	    vk::AccessFlagBits2::eColorAttachmentWrite,                // dstAccessMask
+	    vk::PipelineStageFlagBits2::eColorAttachmentOutput,        // srcStage
+	    vk::PipelineStageFlagBits2::eColorAttachmentOutput         // dstStage
+	);
 
-		if (vkBeginCommandBuffer(commandBuffers[i], &beginInfo) != VK_SUCCESS) {
-			throw std::runtime_error("failed to begin recording command buffer!");
-		}
+	vk::ClearValue              clearColor     = vk::ClearColorValue(0.0f, 0.0f, 0.0f, 1.0f);
+	vk::RenderingAttachmentInfo attachmentInfo = {
+	    .imageView   = swapChain.getImageView(imageIndex),
+	    .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
+	    .loadOp      = vk::AttachmentLoadOp::eClear,
+	    .storeOp     = vk::AttachmentStoreOp::eStore,
+	    .clearValue  = clearColor,
+	};
+	vk::RenderingInfo renderingInfo = {
+	    .renderArea           = {.offset = {0, 0}, .extent = swapChain.getSwapChainExtent()},
+	    .layerCount           = 1,
+	    .colorAttachmentCount = 1,
+	    .pColorAttachments    = &attachmentInfo,
+	    .pDepthAttachment     = nullptr,
+	    .pStencilAttachment   = nullptr,
+	};
 
-		VkRenderPassBeginInfo remderPassInfo{};
-		remderPassInfo.sType             = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-		remderPassInfo.renderPass        = swapChain.getRenderPass();
-		remderPassInfo.framebuffer       = swapChain.getFrameBuffer(i);
-		remderPassInfo.renderArea.offset = {0, 0};
-		remderPassInfo.renderArea.extent = swapChain.getSwapChainExtent();
+	commandBuffer.beginRendering(renderingInfo);
+	pipeline->bind(commandBuffer);
+	commandBuffer.setViewport(0, swapChain.getViewport());
+	commandBuffer.setScissor(0, swapChain.getScissor());
+	model->bind(commandBuffer);
+	model->draw(commandBuffer);
+	commandBuffer.endRendering();
 
-		std::array<VkClearValue, 2> clearValues{};
-		clearValues[0].color           = {0.1f, 0.1f, 0.1f, 1.0f};
-		clearValues[1].depthStencil    = {1.0f, 0};
-		remderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
-		remderPassInfo.pClearValues    = clearValues.data();
+	transitionImageLayout(
+	    imageIndex,
+	    vk::ImageLayout::eColorAttachmentOptimal,
+	    vk::ImageLayout::ePresentSrcKHR,
+	    vk::AccessFlagBits2::eColorAttachmentWrite,                // srcAccessMask
+	    vk::AccessFlagBits2{},                                     // dstAccessMask
+	    vk::PipelineStageFlagBits2::eColorAttachmentOutput,        // srcStage
+	    vk::PipelineStageFlagBits2::eBottomOfPipe                  // dstStage
+	);
 
-		vkCmdBeginRenderPass(commandBuffers[i], &remderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+	commandBuffer.end();
+}
 
-		pipeline->bind(commandBuffers[i]);
-		model->bind(commandBuffers[i]);
-		model->draw(commandBuffers[i]);
+void FirstApp::transitionImageLayout(
+    uint32_t                imageIndex,
+    vk::ImageLayout         oldLayout,
+    vk::ImageLayout         newLayout,
+    vk::AccessFlags2        srcAccessMask,
+    vk::AccessFlags2        dstAccessMask,
+    vk::PipelineStageFlags2 srcStageMask,
+    vk::PipelineStageFlags2 dstStageMask)
+{
+	vk::ImageMemoryBarrier2 barrier = {
+	    .srcStageMask        = srcStageMask,
+	    .srcAccessMask       = srcAccessMask,
+	    .dstStageMask        = dstStageMask,
+	    .dstAccessMask       = dstAccessMask,
+	    .oldLayout           = oldLayout,
+	    .newLayout           = newLayout,
+	    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+	    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+	    .image               = swapChain.getImage(imageIndex),
+	    .subresourceRange    = {
+	           .aspectMask     = vk::ImageAspectFlagBits::eColor,
+	           .baseMipLevel   = 0,
+	           .levelCount     = 1,
+	           .baseArrayLayer = 0,
+	           .layerCount     = 1,
+        },
+	};
 
-		vkCmdEndRenderPass(commandBuffers[i]);
-		if (vkEndCommandBuffer(commandBuffers[i]) != VK_SUCCESS) {
-			throw std::runtime_error("failed to end recording command buffer!");
-		}
-	}
+	vk::DependencyInfo dependencyInfo = {
+	    .dependencyFlags         = {},
+	    .imageMemoryBarrierCount = 1,
+	    .pImageMemoryBarriers    = &barrier,
+	};
+
+	commandBuffers[frameIndex].pipelineBarrier2(dependencyInfo);
 }
 
 void FirstApp::drawFrame()
@@ -120,7 +172,8 @@ void FirstApp::drawFrame()
 		throw std::runtime_error("failed to acquire swap chain image!");
 	}
 
-	result = swapChain.submitCommandBuffers(&commandBuffers[imageIndex], &imageIndex);
+	VkCommandBuffer rawCommandBuffer = *commandBuffers[imageIndex];
+	result                           = swapChain.submitCommandBuffers(&rawCommandBuffer, &imageIndex);
 	if (result != VK_SUCCESS) {
 		throw std::runtime_error("failed to submit command buffer!");
 	}

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -1,10 +1,8 @@
 #include "first_app.h"
 
 // std
-#include <array>
 #include <cstdint>
 #include <stdexcept>
-#include <vulkan/vulkan_core.h>
 
 namespace mvr
 {
@@ -165,18 +163,27 @@ void FirstApp::transitionImageLayout(
 
 void FirstApp::drawFrame()
 {
-	uint32_t imageIndex;
-	auto     result = swapChain.acquireNextImage(&imageIndex);
+	auto [result, imageIndex] = swapChain.acquireNextImage(frameIndex);
 
-	if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
+	if (result != vk::Result::eSuccess && result != vk::Result::eSuboptimalKHR) {
 		throw std::runtime_error("failed to acquire swap chain image!");
 	}
 
-	VkCommandBuffer rawCommandBuffer = *commandBuffers[imageIndex];
-	result                           = swapChain.submitCommandBuffers(&rawCommandBuffer, &imageIndex);
-	if (result != VK_SUCCESS) {
-		throw std::runtime_error("failed to submit command buffer!");
+	commandBuffers[frameIndex].reset();
+	recordCommandBuffer(imageIndex);
+
+	result = swapChain.submitCommandBuffers(commandBuffers[frameIndex], imageIndex, frameIndex);
+	switch (result) {
+		case vk::Result::eSuccess:
+			break;
+		case vk::Result::eSuboptimalKHR:
+			// Optionally handle suboptimal swap chain
+			break;
+		default:
+			throw std::runtime_error("failed to present swap chain image!");
 	}
+
+	frameIndex = (frameIndex + 1) % SwapChain::MAX_FRAMES_IN_FLIGHT;
 }
 
 }        // namespace mvr

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -1,5 +1,4 @@
 #include "first_app.h"
-#include "vulkan/vulkan.hpp"
 
 // std
 #include <array>

--- a/src/first_app.h
+++ b/src/first_app.h
@@ -5,7 +5,6 @@
 #include "core/vulkan_device.h"
 #include "core/window.h"
 #include "scene/model.h"
-#include "vulkan/vulkan.hpp"
 
 // std
 #include <cstdint>

--- a/src/first_app.h
+++ b/src/first_app.h
@@ -5,8 +5,10 @@
 #include "core/vulkan_device.h"
 #include "core/window.h"
 #include "scene/model.h"
+#include "vulkan/vulkan.hpp"
 
 // std
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -16,8 +18,9 @@ namespace mvr
 class FirstApp
 {
   public:
-	static constexpr uint32_t WIDTH  = 800;
-	static constexpr uint32_t HEIGHT = 600;
+	static constexpr uint32_t WIDTH      = 800;
+	static constexpr uint32_t HEIGHT     = 600;
+	uint32_t                  frameIndex = 0;
 
 	FirstApp();
 	~FirstApp();
@@ -28,19 +31,31 @@ class FirstApp
 	void run();
 
   private:
-	Window                       window{WIDTH, HEIGHT, "MyVulkanRenderer"};
-	VulkanDevice                 device{window};
-	SwapChain                    swapChain{device, window.getExtent()};
-	std::unique_ptr<Pipeline>    pipeline;
-	vk::raii::PipelineLayout     pipelineLayout = nullptr;
-	std::vector<VkCommandBuffer> commandBuffers;
-	std::unique_ptr<Model>       model;
+	Window                               window{WIDTH, HEIGHT, "MyVulkanRenderer"};
+	VulkanDevice                         device{window};
+	SwapChain                            swapChain{device, window.getExtent()};
+	std::unique_ptr<Pipeline>            pipeline;
+	vk::raii::PipelineLayout             pipelineLayout = nullptr;
+	std::vector<vk::raii::CommandBuffer> commandBuffers;
+	std::unique_ptr<Model>               model;
 
 	void loadModel();
 	void createPipelineLayout();
 	void createPipeline();
 	void createCommandBuffers();
+
+	void recordCommandBuffer(uint32_t imageIndex);
 	void drawFrame();
+
+	// Helper Methods
+	void transitionImageLayout(
+	    uint32_t                imageIndex,
+	    vk::ImageLayout         oldLayout,
+	    vk::ImageLayout         newLayout,
+	    vk::AccessFlags2        srcAccessMask,
+	    vk::AccessFlags2        dstAccessMask,
+	    vk::PipelineStageFlags2 srcStageMask,
+	    vk::PipelineStageFlags2 dstStageMask);
 };
 
 }        // namespace mvr

--- a/src/first_app.h
+++ b/src/first_app.h
@@ -32,7 +32,7 @@ class FirstApp
 	VulkanDevice                 device{window};
 	SwapChain                    swapChain{device, window.getExtent()};
 	std::unique_ptr<Pipeline>    pipeline;
-	VkPipelineLayout             pipelineLayout;
+	vk::raii::PipelineLayout     pipelineLayout = nullptr;
 	std::vector<VkCommandBuffer> commandBuffers;
 	std::unique_ptr<Model>       model;
 

--- a/src/scene/model.cpp
+++ b/src/scene/model.cpp
@@ -1,4 +1,3 @@
-#include <cstdint>
 #include <scene/model.h>
 
 // std

--- a/src/scene/model.cpp
+++ b/src/scene/model.cpp
@@ -40,8 +40,8 @@ Model::Model(VulkanDevice &device, const std::vector<Vertex> &vertices) : device
 
 Model::~Model()
 {
-	vkDestroyBuffer(device.device(), vertexBuffer, nullptr);
-	vkFreeMemory(device.device(), vertexBufferMemory, nullptr);
+	vkDestroyBuffer(*device.device(), vertexBuffer, nullptr);
+	vkFreeMemory(*device.device(), vertexBufferMemory, nullptr);
 }
 
 void Model::bind(VkCommandBuffer commandBuffer)
@@ -68,9 +68,9 @@ void Model::createVertexBuffers(const std::vector<Vertex> &vertices)
 	                    vertexBufferMemory);
 
 	void *data;
-	vkMapMemory(device.device(), vertexBufferMemory, 0, bufferSize, 0, &data);
+	vkMapMemory(*device.device(), vertexBufferMemory, 0, bufferSize, 0, &data);
 	memcpy(data, vertices.data(), bufferSize);
-	vkUnmapMemory(device.device(), vertexBufferMemory);
+	vkUnmapMemory(*device.device(), vertexBufferMemory);
 }
 
 }        // namespace mvr

--- a/src/scene/model.cpp
+++ b/src/scene/model.cpp
@@ -7,27 +7,27 @@
 namespace mvr
 {
 
-std::vector<VkVertexInputBindingDescription> Model::Vertex::getBindingDescriptions()
+std::vector<vk::VertexInputBindingDescription> Model::Vertex::getBindingDescriptions()
 {
-	std::vector<VkVertexInputBindingDescription> bindingDescriptions(1);
+	std::vector<vk::VertexInputBindingDescription> bindingDescriptions(1);
 	bindingDescriptions[0].binding   = 0;
 	bindingDescriptions[0].stride    = sizeof(Vertex);
-	bindingDescriptions[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+	bindingDescriptions[0].inputRate = vk::VertexInputRate::eVertex;
 
 	return bindingDescriptions;
 }
 
-std::vector<VkVertexInputAttributeDescription> Model::Vertex::getAttributeDescriptions()
+std::vector<vk::VertexInputAttributeDescription> Model::Vertex::getAttributeDescriptions()
 {
-	std::vector<VkVertexInputAttributeDescription> attributeDescriptions(2);
+	std::vector<vk::VertexInputAttributeDescription> attributeDescriptions(2);
 	attributeDescriptions[0].binding  = 0;
 	attributeDescriptions[0].location = 0;
-	attributeDescriptions[0].format   = VK_FORMAT_R32G32_SFLOAT;
+	attributeDescriptions[0].format   = vk::Format::eR32G32Sfloat;
 	attributeDescriptions[0].offset   = offsetof(Vertex, position);
 
 	attributeDescriptions[1].binding  = 0;
 	attributeDescriptions[1].location = 1;
-	attributeDescriptions[1].format   = VK_FORMAT_R32G32B32_SFLOAT;
+	attributeDescriptions[1].format   = vk::Format::eR32G32B32Sfloat;
 	attributeDescriptions[1].offset   = offsetof(Vertex, color);
 
 	return attributeDescriptions;

--- a/src/scene/model.cpp
+++ b/src/scene/model.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <scene/model.h>
 
 // std
@@ -7,70 +8,47 @@
 namespace mvr
 {
 
-std::vector<vk::VertexInputBindingDescription> Model::Vertex::getBindingDescriptions()
-{
-	std::vector<vk::VertexInputBindingDescription> bindingDescriptions(1);
-	bindingDescriptions[0].binding   = 0;
-	bindingDescriptions[0].stride    = sizeof(Vertex);
-	bindingDescriptions[0].inputRate = vk::VertexInputRate::eVertex;
-
-	return bindingDescriptions;
-}
-
-std::vector<vk::VertexInputAttributeDescription> Model::Vertex::getAttributeDescriptions()
-{
-	std::vector<vk::VertexInputAttributeDescription> attributeDescriptions(2);
-	attributeDescriptions[0].binding  = 0;
-	attributeDescriptions[0].location = 0;
-	attributeDescriptions[0].format   = vk::Format::eR32G32Sfloat;
-	attributeDescriptions[0].offset   = offsetof(Vertex, position);
-
-	attributeDescriptions[1].binding  = 0;
-	attributeDescriptions[1].location = 1;
-	attributeDescriptions[1].format   = vk::Format::eR32G32B32Sfloat;
-	attributeDescriptions[1].offset   = offsetof(Vertex, color);
-
-	return attributeDescriptions;
-}
-
 Model::Model(VulkanDevice &device, const std::vector<Vertex> &vertices) : device{device}
 {
 	createVertexBuffers(vertices);
 }
 
-Model::~Model()
+void Model::bind(vk::CommandBuffer commandBuffer)
 {
-	vkDestroyBuffer(*device.device(), vertexBuffer, nullptr);
-	vkFreeMemory(*device.device(), vertexBufferMemory, nullptr);
+	commandBuffer.bindVertexBuffers(0, *vertexBuffer, {0});
 }
 
-void Model::bind(VkCommandBuffer commandBuffer)
+void Model::draw(vk::CommandBuffer commandBuffer)
 {
-	VkBuffer     buffers[] = {vertexBuffer};
-	VkDeviceSize offsets[] = {0};
-	vkCmdBindVertexBuffers(commandBuffer, 0, 1, buffers, offsets);
-}
-
-void Model::draw(VkCommandBuffer commandBuffer)
-{
-	vkCmdDraw(commandBuffer, vertexCount, 1, 0, 0);
+	commandBuffer.draw(vertexCount, 1, 0, 0);
 }
 
 void Model::createVertexBuffers(const std::vector<Vertex> &vertices)
 {
 	vertexCount = static_cast<uint32_t>(vertices.size());
-	assert(vertexCount >= 3 && "vertex count must be at least 3");
-	VkDeviceSize bufferSize = sizeof(vertices[0]) * vertexCount;
-	device.createBuffer(bufferSize,
-	                    VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-	                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	                    vertexBuffer,
-	                    vertexBufferMemory);
 
-	void *data;
-	vkMapMemory(*device.device(), vertexBufferMemory, 0, bufferSize, 0, &data);
-	memcpy(data, vertices.data(), bufferSize);
-	vkUnmapMemory(*device.device(), vertexBufferMemory);
+	vk::BufferCreateInfo bufferInfo = {
+	    .size        = sizeof(vertices[0]) * vertices.size(),
+	    .usage       = vk::BufferUsageFlagBits::eVertexBuffer,
+	    .sharingMode = vk::SharingMode::eExclusive,
+	};
+
+	vertexBuffer = vk::raii::Buffer(device.device(), bufferInfo);
+
+	vk::MemoryRequirements memRequirements = vertexBuffer.getMemoryRequirements();
+	vk::MemoryAllocateInfo memAllocateInfo = {
+	    .allocationSize  = memRequirements.size,
+	    .memoryTypeIndex = device.findMemoryType(
+	        memRequirements.memoryTypeBits,
+	        vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent),
+	};
+	vertexBufferMemory = vk::raii::DeviceMemory(device.device(), memAllocateInfo);
+
+	vertexBuffer.bindMemory(*vertexBufferMemory, 0);
+
+	void *data = vertexBufferMemory.mapMemory(0, bufferInfo.size);
+	memcpy(data, vertices.data(), bufferInfo.size);
+	vertexBufferMemory.unmapMemory();
 }
 
 }        // namespace mvr

--- a/src/scene/model.h
+++ b/src/scene/model.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core/vulkan_device.h"
-#include <vulkan/vulkan_core.h>
 
 // libs
 #define GLM_FORCE_RADIANS
@@ -21,24 +20,47 @@ class Model
 		glm::vec2 position;
 		glm::vec3 color;
 
-		static std::vector<vk::VertexInputBindingDescription>   getBindingDescriptions();
-		static std::vector<vk::VertexInputAttributeDescription> getAttributeDescriptions();
+		static std::vector<vk::VertexInputBindingDescription> getBindingDescriptions()
+		{
+			return {
+			    {
+			        .binding   = 0,
+			        .stride    = sizeof(Vertex),
+			        .inputRate = vk::VertexInputRate::eVertex,
+			    },
+			};
+		}
+		static std::vector<vk::VertexInputAttributeDescription> getAttributeDescriptions()
+		{
+			return {
+			    {
+			        .location = 0,
+			        .binding  = 0,
+			        .format   = vk::Format::eR32G32Sfloat,
+			        .offset   = offsetof(Vertex, position),
+			    },
+			    {
+			        .location = 1,
+			        .binding  = 0,
+			        .format   = vk::Format::eR32G32B32Sfloat,
+			        .offset   = offsetof(Vertex, color),
+			    },
+			};
+		}
 	};
 
 	Model(VulkanDevice &device, const std::vector<Vertex> &vertices);
-	~Model();
-
 	Model(const Model &)            = delete;
 	Model &operator=(const Model &) = delete;
 
-	void bind(VkCommandBuffer commandBuffer);
-	void draw(VkCommandBuffer commandBuffer);
+	void bind(vk::CommandBuffer commandBuffer);
+	void draw(vk::CommandBuffer commandBuffer);
 
   private:
-	VulkanDevice  &device;
-	VkBuffer       vertexBuffer;
-	VkDeviceMemory vertexBufferMemory;
-	uint32_t       vertexCount;
+	VulkanDevice          &device;
+	vk::raii::Buffer       vertexBuffer       = nullptr;
+	vk::raii::DeviceMemory vertexBufferMemory = nullptr;
+	uint32_t               vertexCount;
 
 	void createVertexBuffers(const std::vector<Vertex> &vertices);
 };

--- a/src/scene/model.h
+++ b/src/scene/model.h
@@ -21,8 +21,8 @@ class Model
 		glm::vec2 position;
 		glm::vec3 color;
 
-		static std::vector<VkVertexInputBindingDescription>   getBindingDescriptions();
-		static std::vector<VkVertexInputAttributeDescription> getAttributeDescriptions();
+		static std::vector<vk::VertexInputBindingDescription>   getBindingDescriptions();
+		static std::vector<vk::VertexInputAttributeDescription> getAttributeDescriptions();
 	};
 
 	Model(VulkanDevice &device, const std::vector<Vertex> &vertices);


### PR DESCRIPTION
- closes #1
- Successfully migrated triangle rendering to RAII.
- Remaining `Vk` handles will be replaced in future updates as feature development progresses.